### PR TITLE
Correcting pressure loss in heat exhangers

### DIFF
--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondReheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondReheater_PartialCondensation.mo
@@ -20,8 +20,6 @@ public
   Modelica.SIunits.MassFlowRate Q_hot(start=50) "Inlet Mass flow rate";
   MetroscopeModelingLibrary.Common.Units.DifferentialPressure deltaP_cold "Singular pressure loss";
   MetroscopeModelingLibrary.Common.Units.DifferentialPressure deltaP_hot "Singular pressure loss";
-  Modelica.SIunits.Density coldSide_rhom;
-  Modelica.SIunits.Density hotSide_rhom;
   Modelica.SIunits.Temperature T_hot_in "hot fluid temperature in K at inlet";
   Modelica.SIunits.Temperature T_hot_out "hot fluid temperature in K at outlet";
   Modelica.SIunits.Temperature T_cold_in "hot fluid temperature in K at inlet";
@@ -58,17 +56,15 @@ equation
   // The pressure loss coefficient, is however calculated for the whole system, for both sides.
 
   //in CondReH on cold side
-  coldSide_rhom =(condensing_cold.rho_in + deheating_cold.rho_out)/2;
   deltaP_cold =-Kfr_cold*
     MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold,
-    condensing_cold.eps)/coldSide_rhom;
+    condensing_cold.eps)/condensing_cold.rho_in;
   deltaP_cold =condensing_cold.P_out - condensing_cold.P_in;
   deheating_cold.P_in = deheating_cold.P_out;
 
   //DesHReH on hot side.
-  hotSide_rhom =(deheating_hot.rho_in + condensing_hot.rho_out)/2;
   deltaP_hot =-Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(
-    Q_hot, deheating_hot.eps)/hotSide_rhom;
+    Q_hot, deheating_hot.eps)/deheating_hot.rho_in;
   deltaP_hot =deheating_hot.P_out - deheating_hot.P_in;
   condensing_hot.P_in = condensing_hot.P_out;
 

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondenserSimple.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondenserSimple.mo
@@ -57,7 +57,7 @@ equation
   coldSide.Q_in + coldSide.Q_out = 0;
   coldSide.Q_in*coldSide.h_in + coldSide.Q_out*coldSide.h_out = -W;
   deltaP_cold = coldSide.P_in - coldSide.P_out;
-  deltaP_cold = Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(coldSide.Q_in, coldSide.eps)/coldSide.rhom;
+  deltaP_cold = Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(coldSide.Q_in, coldSide.eps)/coldSide.rho_in;
   0 = Tsat - coldSide.T_out - (Tsat - coldSide.T_in)*exp(Kth*S*((coldSide.T_in - coldSide.T_out)/W));
   if mass_balance then
     hotSide.Q_in+hotSide.Q_out = 0;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -40,8 +40,8 @@ public
         iconTransformation(extent={{50,-90},{70,-70}})));
 equation
   // Pressure loss
-  deltaP_cold = Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold, coldSide.eps)/coldSide.rhom;
-  deltaP_hot = Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_hot,hotSide.eps)/hotSide.rhom;
+  deltaP_cold = Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold, coldSide.eps)/coldSide.rho_in;
+  deltaP_hot = Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_hot,hotSide.eps)/hotSide.rho_in;
   deltaP_cold = coldSide.P_out - coldSide.P_in;
   deltaP_hot = hotSide.P_out - hotSide.P_in;
 

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -25,8 +25,6 @@ model Reheater
   MetroscopeModelingLibrary.Common.Units.DifferentialPressure deltaP_cold "Singular pressure loss";
   Modelica.SIunits.MassFlowRate Q_hot(start=50) "Inlet Mass flow rate";
   MetroscopeModelingLibrary.Common.Units.DifferentialPressure deltaP_hot "Singular pressure loss";
-  Modelica.SIunits.Density coldSide_rhom;
-  Modelica.SIunits.Density hotSide_rhom;
   Modelica.SIunits.Temperature T_hot_in "hot fluid temperature in K at inlet";
   Modelica.SIunits.Temperature T_hot_out "hot fluid temperature in deg_C at outlet";
   Modelica.SIunits.Temperature T_cold_in "hot fluid temperature in deg_C at inlet";
@@ -69,10 +67,8 @@ equation
   // Pressure loss
   // For convenience, the whole pressure loss in the component is modelized as only occuring in the deheating part.
   // The pressure loss coefficient, is however calculated for the whole system, for both sides.
-  coldSide_rhom = (purge_cold.rho_in + deheating_cold.rho_out)/2;
-  hotSide_rhom = (deheating_hot.rho_in + purge_hot.rho_out)/2;
-  deltaP_cold = Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold, deheating_cold.eps)/coldSide_rhom;
-  deltaP_hot = Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_hot,deheating_hot.eps)/hotSide_rhom;
+  deltaP_cold = Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold, deheating_cold.eps)/purge_cold.rho_in;
+  deltaP_hot = Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_hot,deheating_hot.eps)/deheating_hot.rho_in;
   deltaP_cold = deheating_cold.P_in - deheating_cold.P_out;
   deltaP_hot = deheating_hot.P_in - deheating_hot.P_out;
   condensing_hot.P_in = condensing_hot.P_out;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater_PartialCondensation.mo
@@ -19,8 +19,6 @@ model Superheater_PartialCondensation
   Modelica.SIunits.MassFlowRate Q_hot_in(start=50) "Inlet Mass flow rate, hot side";
   MetroscopeModelingLibrary.Common.Units.DifferentialPressure deltaP_cold "Singular pressure loss";
   MetroscopeModelingLibrary.Common.Units.DifferentialPressure deltaP_hot "Singular pressure loss";
-  Modelica.SIunits.Density coldSide_rhom;
-  Modelica.SIunits.Density hotSide_rhom;
   Modelica.SIunits.Temperature T_hot_in "hot fluid temperature in K at inlet";
   Modelica.SIunits.Temperature T_hot_out "hot fluid temperature in K at outlet";
   Modelica.SIunits.Temperature T_cold_in "hot fluid temperature in K at inlet";
@@ -77,15 +75,13 @@ equation
   // For convenience, the whole pressure loss in the component is modelized as only occuring in one zone.
   // The pressure loss coefficient, is however calculated for the whole system, for both sides.
   //in CondVap on cold side
-  coldSide_rhom =(CondVap_cold.rho_in + DesHSupH_cold.rho_out)/2;
-  deltaP_cold = -Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold, CondVap_cold.eps)/coldSide_rhom;
+  deltaP_cold = -Kfr_cold*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_cold, CondVap_cold.eps)/CondVap_cold.rho_in;
   deltaP_cold = CondVap_cold.P_out - CondVap_cold.P_in;
   CondSupH_cold.P_in = CondSupH_cold.P_out;
   DesHSupH_cold.P_in = DesHSupH_cold.P_out;
 
   //in DesHSupH on hot side.
-  hotSide_rhom =(DesHSupH_hot.rho_in + CondVap_hot.rho_out)/2;
-  deltaP_hot = -Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_hot_in,DesHSupH_hot.eps)/hotSide_rhom;
+  deltaP_hot = -Kfr_hot*MetroscopeModelingLibrary.Common.Functions.ThermoSquare(Q_hot_in,DesHSupH_hot.eps)/DesHSupH_hot.rho_in;
   deltaP_hot = DesHSupH_hot.P_out - DesHSupH_hot.P_in;
   CondSupH_hot.P_in = CondSupH_hot.P_out;
   CondVap_hot.P_in = CondVap_hot.P_out;


### PR DESCRIPTION
Correction on computation of pressure loss in heat exchangers : the inlet rho is used instead of a mean between inlet and outlet. 