### PR TITLE
Made PartialCondensation models non-partial and balanced

### DIFF
--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondReheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondReheater_PartialCondensation.mo
@@ -1,5 +1,5 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
-partial model CondReheater_PartialCondensation
+model CondReheater_PartialCondensation
   replaceable package ColdMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   replaceable package HotMedium =
@@ -8,12 +8,13 @@ partial model CondReheater_PartialCondensation
   connector InputReal = input Real;
   connector InputCoefficientOfHeatTransfer = input
       Modelica.Units.SI.CoefficientOfHeatTransfer;
+  connector InputArea = input Modelica.Units.SI.Area;
 
   InputReal Kfr_cold(start=1.e3) "Pressure loss coefficient";
   InputReal Kfr_hot(start=1.e3) "Pressure loss coefficient";
   InputCoefficientOfHeatTransfer Kth(start=9000)
     "heat transfer coefficient same in all zone";
-  Modelica.Units.SI.Area S_tot(start=100) "Total exchange area";
+  InputArea S_tot(start=100) "Total exchange area";
   Modelica.Units.SI.Power W_CondReH(start=40e6)
     "Energy transfer in CondVap zone";
   Modelica.Units.SI.Area S_CondReH(start=90) "Exchange area in CondVap zone";

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater_PartialCondensation.mo
@@ -1,5 +1,5 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
-partial model Superheater_PartialCondensation
+model Superheater_PartialCondensation
   replaceable package ColdMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   replaceable package HotMedium =
@@ -8,12 +8,13 @@ partial model Superheater_PartialCondensation
   connector InputReal = input Real;
   connector InputCoefficientOfHeatTransfer = input
       Modelica.Units.SI.CoefficientOfHeatTransfer;
+  connector InputArea = input Modelica.Units.SI.Area;
 
   InputReal Kfr_cold(start=1.e3) "Pressure loss coefficient";
   InputReal Kfr_hot(start=1.e3) "Pressure loss coefficient";
   InputCoefficientOfHeatTransfer Kth(start=9000)
     "heat transfer coefficient same in all zone";
-  Modelica.Units.SI.Area S_tot(start=100) "Total exchange area";
+  InputArea S_tot(start=100) "Total exchange area";
   Modelica.Units.SI.Power W_CondVap(start=0.5e6)
     "Energy transfer in CondVap zone";
   Modelica.Units.SI.Power W_CondSupH(start=40e6)


### PR DESCRIPTION
PartialCondensation models are used in test models, where an equation is added to set the `S_tot` area. Hence the model cannot be partial, and in order to make it balanced, `S_tot` is defined as an input connector, with the usual semantics.