### PR TITLE
Revert "Changed default start values in basic models for improved convergence"

### DIFF
--- a/MetroscopeModelingLibrary/Common/BoundaryConditions/PartialBoundaryCondition.mo
+++ b/MetroscopeModelingLibrary/Common/BoundaryConditions/PartialBoundaryCondition.mo
@@ -8,12 +8,12 @@ model PartialBoundaryCondition
   connector InputSpecificEnthalpy = input Modelica.Units.SI.SpecificEnthalpy;
   connector InputMassFraction = input Medium.MassFraction;
 
-  Modelica.Units.SI.MassFlowRate Q(start=200);
-  InputAbsolutePressure P(start=60e5);
+  Modelica.Units.SI.MassFlowRate Q(start=500);
+  InputAbsolutePressure P(start=1e5);
   Modelica.Units.SI.Temperature T(start=293.15);
   Modelica.Units.SI.Temperature T_vol(start=293.15);
-  Modelica.Units.SI.SpecificEnthalpy h(start=3.2e6);
-  InputSpecificEnthalpy h_vol(start=3.2e6);
+  Modelica.Units.SI.SpecificEnthalpy h(start=1e5);
+  InputSpecificEnthalpy h_vol(start=1e5);
   Modelica.Units.SI.MassFlowRate Qi[Medium.nXi];
   InputMassFraction Xi_vol[Medium.nXi];
   Medium.MassFraction Xi[Medium.nXi];

--- a/MetroscopeModelingLibrary/Common/BoundaryConditions/Sink.mo
+++ b/MetroscopeModelingLibrary/Common/BoundaryConditions/Sink.mo
@@ -7,13 +7,13 @@ model Sink
   connector InputSpecificEnthalpy = input Modelica.Units.SI.SpecificEnthalpy;
   connector InputMassFraction = input Medium.MassFraction;
 
-  Modelica.Units.SI.MassFlowRate Q_in(start=200);
-  Modelica.Units.SI.VolumeFlowRate Qv_in(start=200);
-  InputAbsolutePressure P_in(start=60e5);
+  Modelica.Units.SI.MassFlowRate Q_in(start=500);
+  Modelica.Units.SI.VolumeFlowRate Qv_in(start=500);
+  InputAbsolutePressure P_in(start=1e5);
   Modelica.Units.SI.Temperature T_in(start=293.15);
   Modelica.Units.SI.Temperature T_vol(start=293.15);
-  Modelica.Units.SI.SpecificEnthalpy h_in(start=3.2e6);
-  InputSpecificEnthalpy h_vol(start=3.2e6);
+  Modelica.Units.SI.SpecificEnthalpy h_in(start=1e5);
+  InputSpecificEnthalpy h_vol(start=1e5);
   Modelica.Units.SI.MassFlowRate Qi_in[Medium.nXi];
   InputMassFraction Xi_vol[Medium.nXi];
   Medium.MassFraction Xi_in[Medium.nXi];

--- a/MetroscopeModelingLibrary/Common/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/Common/BoundaryConditions/Source.mo
@@ -7,13 +7,13 @@ model Source
   connector InputSpecificEnthalpy = input Modelica.Units.SI.SpecificEnthalpy;
   connector InputMassFraction = input Medium.MassFraction;
 
-  Modelica.Units.SI.MassFlowRate Q_out(start=200);
-  Modelica.Units.SI.VolumeFlowRate Qv_out(start=200);
-  InputAbsolutePressure P_out(start=60e5);
+  Modelica.Units.SI.MassFlowRate Q_out(start=500);
+  Modelica.Units.SI.VolumeFlowRate Qv_out(start=500);
+  InputAbsolutePressure P_out(start=1e5);
   Modelica.Units.SI.Temperature T_out(start=293.15);
   Modelica.Units.SI.Temperature T_vol(start=293.15);
-  Modelica.Units.SI.SpecificEnthalpy h_out(start=3.2e6);
-  InputSpecificEnthalpy h_vol(start=3.2e6);
+  Modelica.Units.SI.SpecificEnthalpy h_out(start=1e5);
+  InputSpecificEnthalpy h_vol(start=1e5);
   Modelica.Units.SI.MassFlowRate Qi_out[Medium.nXi];
   InputMassFraction Xi_vol[Medium.nXi];
     Medium.MassFraction Xi_out[Medium.nXi];

--- a/MetroscopeModelingLibrary/Common/Connectors/FluidOutlet.mo
+++ b/MetroscopeModelingLibrary/Common/Connectors/FluidOutlet.mo
@@ -1,8 +1,6 @@
 within MetroscopeModelingLibrary.Common.Connectors;
 connector FluidOutlet
-  extends MetroscopeModelingLibrary.Common.Connectors.FluidPort(
-    Q(start = -200),
-    H(start = -2e8));
+  extends MetroscopeModelingLibrary.Common.Connectors.FluidPort;
   annotation (defaultComponentName="C_out",
   Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
             {100,100}}),                                       graphics={

--- a/MetroscopeModelingLibrary/Common/Connectors/FluidPort.mo
+++ b/MetroscopeModelingLibrary/Common/Connectors/FluidPort.mo
@@ -3,11 +3,11 @@ connector FluidPort
   //extends Modelica.Fluid.Interfaces.FluidPort
   replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
     "Medium model" annotation (choicesAllMatching=true);
-  flow Modelica.Units.SI.MassFlowRate Q(start=200);
+  flow Modelica.Units.SI.MassFlowRate Q(start=500);
   flow Modelica.Units.SI.MassFlowRate Qi[Medium.nXi];
-  flow Modelica.Units.SI.Power H(start=2e8);
-  Modelica.Units.SI.AbsolutePressure P(start=60e5);
-  Modelica.Units.SI.SpecificEnthalpy h_vol(start=3.2e6);
+  flow Modelica.Units.SI.Power H(start=5.e7);
+  Modelica.Units.SI.AbsolutePressure P(start=1.e5);
+  Modelica.Units.SI.SpecificEnthalpy h_vol(start=1.e5);
   Medium.MassFraction Xi_vol[Medium.nXi];
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
         coordinateSystem(preserveAspectRatio=false)));

--- a/MetroscopeModelingLibrary/Common/Partial/BasicTransportModel.mo
+++ b/MetroscopeModelingLibrary/Common/Partial/BasicTransportModel.mo
@@ -12,11 +12,11 @@ model BasicTransportModel
   Modelica.Units.SI.VolumeFlowRate Qv_in(start=0.1) "inlet volume flow rate";
   Modelica.Units.SI.VolumeFlowRate Qv_out(start=0.1) "outlet volume flow rate";
   Modelica.Units.SI.VolumeFlowRate Qvm(start=0.1) "mean volume flow rate";
-  Modelica.Units.SI.SpecificEnthalpy h_in(start=3.2e6)
+  Modelica.Units.SI.SpecificEnthalpy h_in(start=100000)
     "Inlet specific enthalpy";
-  Modelica.Units.SI.SpecificEnthalpy h_out(start=3.2e6)
+  Modelica.Units.SI.SpecificEnthalpy h_out(start=100000)
     "Outlet specific enthalpy";
-  Modelica.Units.SI.SpecificEnthalpy hm(start=3.2e6)
+  Modelica.Units.SI.SpecificEnthalpy hm(start=100000)
     "Average specific enthalpy";
   Modelica.Units.SI.Density rho_in(start=998) "Fluid density";
   Modelica.Units.SI.Density rho_out(start=998) "Fluid density";


### PR DESCRIPTION
Reverts Metroscope-dev/metroscope-modeling-library#43

We checked all unit tests with Dymola. Unfortunately, while the OpenModelica solver manages to solve all the tests with liquid water despite the vapour enthalpy values, Dymola fails on them. Too bad.

You can test this solution by checking out the [change_h_defaults](https://github.com/Metroscope-dev/metroscope-modeling-library/tree/change_h_defaults) branch.

The correct solution to this issue is to implement stream connectors and proper first tentative initialization via parameters