### PR TITLE
Only one step for static models with no changes in inputs. Partially …

### DIFF
--- a/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_direct_withStartValues.mo
+++ b/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_direct_withStartValues.mo
@@ -3275,7 +3275,6 @@ model MetroscopiaNPP_direct_withStartValues
     phase(start=0))))));
   annotation (experiment(
       StopTime=1,
-      __Dymola_NumberOfIntervals=10,
-      __Dymola_fixedstepsize=0.1,
+      Interval = 1,
       __Dymola_Algorithm="Euler"));
 end MetroscopiaNPP_direct_withStartValues;

--- a/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_faulty_withStartValues.mo
+++ b/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_faulty_withStartValues.mo
@@ -3274,7 +3274,7 @@ model MetroscopiaNPP_faulty_withStartValues
     p(start=5778189.0),
     phase(start=0))))));
   annotation (experiment(
-      __Dymola_NumberOfIntervals=10,
-      __Dymola_fixedstepsize=0.1,
+      StopTime=1,
+      Interval = 1,
       __Dymola_Algorithm="Euler"));
 end MetroscopiaNPP_faulty_withStartValues;

--- a/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_reverse_withStartValues.mo
+++ b/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_reverse_withStartValues.mo
@@ -3300,7 +3300,6 @@ model MetroscopiaNPP_reverse_withStartValues
     phase(start=0))))));
   annotation (experiment(
       StopTime=1,
-      __Dymola_NumberOfIntervals=10,
-      __Dymola_fixedstepsize=0.1,
+      Interval = 1,
       __Dymola_Algorithm="Euler"));
 end MetroscopiaNPP_reverse_withStartValues;


### PR DESCRIPTION
Improves #24 by only computing two simulation steps instead of the default 500