### PR TITLE
Made Common package partial

### DIFF
--- a/MetroscopeModelingLibrary/Common/package.mo
+++ b/MetroscopeModelingLibrary/Common/package.mo
@@ -1,3 +1,3 @@
 within MetroscopeModelingLibrary;
-package Common
+partial package Common "These models are not meant to be used directly"
 end Common;


### PR DESCRIPTION
This prevents end-users from trying to simulate model where components from this package have been used directly. 