### PR TITLE
replaceable keyword removed from fluids (issue #19)

### DIFF
--- a/MetroscopeModelingLibrary/FlueGases/BoundaryConditions/Sink.mo
+++ b/MetroscopeModelingLibrary/FlueGases/BoundaryConditions/Sink.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.BoundaryConditions;
 model Sink
-    replaceable package FlueGasesMedium =
+    package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   extends MetroscopeModelingLibrary.Common.BoundaryConditions.Sink(redeclare
       package                                                                        Medium =

--- a/MetroscopeModelingLibrary/FlueGases/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/FlueGases/BoundaryConditions/Source.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.BoundaryConditions;
 model Source
-  replaceable package FlueGasesMedium =
+  package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   extends MetroscopeModelingLibrary.Common.BoundaryConditions.Source(redeclare
       package                                                                        Medium =

--- a/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.Machines;
 model AirCompressor
-   replaceable package FlueGasesMedium =
+   package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
     extends MetroscopeModelingLibrary.Common.Partial.BasicTransportModel(P_in(start=1e5), P_out(start=45e5),h_in(start=1e5), h_out(start=1.2e5), redeclare package
               Medium =

--- a/MetroscopeModelingLibrary/FlueGases/Machines/FlueGasesTurbine.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Machines/FlueGasesTurbine.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.Machines;
 model FlueGasesTurbine
-   replaceable package FlueGasesMedium =
+   package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
     extends MetroscopeModelingLibrary.Common.Partial.BasicTransportModel(P_in(start=1e5), P_out(start=45e5),h_in(start=1e5), h_out(start=1.2e5), redeclare package
               Medium =

--- a/MetroscopeModelingLibrary/FlueGases/PressureLosses/AdmiLouvers.mo
+++ b/MetroscopeModelingLibrary/FlueGases/PressureLosses/AdmiLouvers.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.PressureLosses;
 model AdmiLouvers
-   replaceable package FlueGasesMedium =
+   package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   extends
     MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureLoss_NoIcon(    redeclare

--- a/MetroscopeModelingLibrary/FlueGases/PressureLosses/Filter.mo
+++ b/MetroscopeModelingLibrary/FlueGases/PressureLosses/Filter.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.PressureLosses;
 model Filter
-   replaceable package FlueGasesMedium =
+   package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   extends
     MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureLoss_NoIcon(    redeclare

--- a/MetroscopeModelingLibrary/FlueGases/PressureLosses/Muffler.mo
+++ b/MetroscopeModelingLibrary/FlueGases/PressureLosses/Muffler.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.PressureLosses;
 model Muffler
-   replaceable package FlueGasesMedium =
+   package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   extends
     MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureLoss_NoIcon(    redeclare

--- a/MetroscopeModelingLibrary/FlueGases/PressureLosses/SingularPressureLoss.mo
+++ b/MetroscopeModelingLibrary/FlueGases/PressureLosses/SingularPressureLoss.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.PressureLosses;
 model SingularPressureLoss
-   replaceable package FlueGasesMedium =
+   package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   extends MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureLoss(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/FlueGases/Sensors/MassFlowFlueGases.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Sensors/MassFlowFlueGases.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.Sensors;
 model MassFlowFlueGases
-    replaceable package FlueGasesMedium =
+    package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
           extends MetroscopeModelingLibrary.Common.Sensors.MassFlowSensor(
                                                       redeclare package Medium =

--- a/MetroscopeModelingLibrary/FlueGases/Sensors/PressureDifferenceFlueGases.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Sensors/PressureDifferenceFlueGases.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.Sensors;
 model PressureDifferenceFlueGases
-      replaceable package FlueGasesMedium =
+      package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.PressureDifferenceSensor(
                                                                           redeclare package

--- a/MetroscopeModelingLibrary/FlueGases/Sensors/PressureFlueGases.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Sensors/PressureFlueGases.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.Sensors;
 model PressureFlueGases
-    replaceable package FlueGasesMedium =
+    package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.PressureSensor(    redeclare package
               Medium = FlueGasesMedium);

--- a/MetroscopeModelingLibrary/FlueGases/Sensors/TemperatureFlueGases.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Sensors/TemperatureFlueGases.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.FlueGases.Sensors;
 model TemperatureFlueGases
-    replaceable package FlueGasesMedium =
+    package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.TemperatureSensor( redeclare package
               Medium = FlueGasesMedium);

--- a/MetroscopeModelingLibrary/Fuel/BoundaryConditions/Sink.mo
+++ b/MetroscopeModelingLibrary/Fuel/BoundaryConditions/Sink.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Fuel.BoundaryConditions;
 model Sink
-      replaceable package FuelMedium =
+      package FuelMedium =
           MetroscopeModelingLibrary.Fuel.Medium.FuelMedium;
       extends MetroscopeModelingLibrary.Common.BoundaryConditions.Sink(redeclare
       package     Medium =

--- a/MetroscopeModelingLibrary/Fuel/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/Fuel/BoundaryConditions/Source.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Fuel.BoundaryConditions;
 model Source
-      replaceable package FuelMedium =
+      package FuelMedium =
           MetroscopeModelingLibrary.Fuel.Medium.FuelMedium;
       extends MetroscopeModelingLibrary.Common.BoundaryConditions.Source(redeclare
       package     Medium =

--- a/MetroscopeModelingLibrary/Fuel/Sensors/MassFlowFuel.mo
+++ b/MetroscopeModelingLibrary/Fuel/Sensors/MassFlowFuel.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Fuel.Sensors;
 model MassFlowFuel
-    replaceable package FuelMedium =
+    package FuelMedium =
       MetroscopeModelingLibrary.Fuel.Medium.FuelMedium;
           extends MetroscopeModelingLibrary.Common.Sensors.MassFlowSensor(
                                                       redeclare package Medium =

--- a/MetroscopeModelingLibrary/Fuel/Sensors/PressureDifferenceFuel.mo
+++ b/MetroscopeModelingLibrary/Fuel/Sensors/PressureDifferenceFuel.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Fuel.Sensors;
 model PressureDifferenceFuel
-      replaceable package FuelMedium =
+      package FuelMedium =
       MetroscopeModelingLibrary.Fuel.Medium.FuelMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.PressureDifferenceSensor(
                                                                           redeclare package Medium =

--- a/MetroscopeModelingLibrary/Fuel/Sensors/PressureFuel.mo
+++ b/MetroscopeModelingLibrary/Fuel/Sensors/PressureFuel.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Fuel.Sensors;
 model PressureFuel
-    replaceable package FuelMedium =
+    package FuelMedium =
       MetroscopeModelingLibrary.Fuel.Medium.FuelMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.PressureSensor(    redeclare package Medium =
                        FuelMedium);

--- a/MetroscopeModelingLibrary/Fuel/Sensors/TemperatureFuel.mo
+++ b/MetroscopeModelingLibrary/Fuel/Sensors/TemperatureFuel.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Fuel.Sensors;
 model TemperatureFuel
-    replaceable package FuelMedium =
+    package FuelMedium =
       MetroscopeModelingLibrary.Fuel.Medium.FuelMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.TemperatureSensor( redeclare package Medium =
                        FuelMedium);

--- a/MetroscopeModelingLibrary/MoistAir/BoundaryConditions/Sink.mo
+++ b/MetroscopeModelingLibrary/MoistAir/BoundaryConditions/Sink.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.MoistAir.BoundaryConditions;
 model Sink
-  replaceable package MoistAirMedium =
+  package MoistAirMedium =
           MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
       extends MetroscopeModelingLibrary.Common.BoundaryConditions.Sink(redeclare
       package     Medium =

--- a/MetroscopeModelingLibrary/MoistAir/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/MoistAir/BoundaryConditions/Source.mo
@@ -1,7 +1,7 @@
 within MetroscopeModelingLibrary.MoistAir.BoundaryConditions;
 model Source
 
-  replaceable package MoistAirMedium =
+  package MoistAirMedium =
           MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
       extends MetroscopeModelingLibrary.Common.BoundaryConditions.Source(redeclare
       package     Medium =

--- a/MetroscopeModelingLibrary/MoistAir/Machines/AirCompressor.mo
+++ b/MetroscopeModelingLibrary/MoistAir/Machines/AirCompressor.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.MoistAir.Machines;
 model AirCompressor
-   replaceable package MoistAirMedium =
+   package MoistAirMedium =
       MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
     extends MetroscopeModelingLibrary.Common.Partial.BasicTransportModel(P_in(start=1e5), P_out(start=45e5),h_in(start=1e5), h_out(start=1.2e5), redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/MoistAir/PressureLosses/SingularPressureAndHeatLoss.mo
+++ b/MetroscopeModelingLibrary/MoistAir/PressureLosses/SingularPressureAndHeatLoss.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.MoistAir.PressureLosses;
 model SingularPressureAndHeatLoss
-   replaceable package MoistAirMedium =
+   package MoistAirMedium =
           MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
   extends
     MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureAndHeatLoss(      redeclare

--- a/MetroscopeModelingLibrary/MoistAir/PressureLosses/SingularPressureLoss.mo
+++ b/MetroscopeModelingLibrary/MoistAir/PressureLosses/SingularPressureLoss.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.MoistAir.PressureLosses;
 model SingularPressureLoss
-  replaceable package MoistAirMedium =
+  package MoistAirMedium =
           MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
       extends
     MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureLoss(          redeclare

--- a/MetroscopeModelingLibrary/Multifluid/HeatExchangers/WaterFlueGasesEvaporator.mo
+++ b/MetroscopeModelingLibrary/Multifluid/HeatExchangers/WaterFlueGasesEvaporator.mo
@@ -1,8 +1,8 @@
 within MetroscopeModelingLibrary.Multifluid.HeatExchangers;
 model WaterFlueGasesEvaporator
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package FlueGasesMedium =
+  package FlueGasesMedium =
       MetroscopeModelingLibrary.FlueGases.Medium.FlueGasesMedium;
   Modelica.Units.SI.Power W(start=1e8);
   Modelica.Units.SI.AbsolutePressure P(start=1e5);

--- a/MetroscopeModelingLibrary/Tests/DymolaTests/SimpleExamples/WaterSteam/MetroscopeTrainingTest.mo
+++ b/MetroscopeModelingLibrary/Tests/DymolaTests/SimpleExamples/WaterSteam/MetroscopeTrainingTest.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Tests.DymolaTests.SimpleExamples.WaterSteam;
 model MetroscopeTrainingTest
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   /* --- Boundary Conditions --- */
   input Real W_heater(start = 35);

--- a/MetroscopeModelingLibrary/Tests/DymolaTests/UnitTests/Multifluid/HeatExchangers/TestNTUCounterCurrentHeatExchanger.mo
+++ b/MetroscopeModelingLibrary/Tests/DymolaTests/UnitTests/Multifluid/HeatExchangers/TestNTUCounterCurrentHeatExchanger.mo
@@ -1,9 +1,9 @@
 within MetroscopeModelingLibrary.Tests.DymolaTests.UnitTests.Multifluid.HeatExchangers;
 model TestNTUCounterCurrentHeatExchanger
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package MoistAirMedium =
+  package MoistAirMedium =
       MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
   MetroscopeModelingLibrary.MoistAir.BoundaryConditions.Source moistAirSource(h_out(
         start=283945), h_vol(start=283945))

--- a/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_topological.mo
+++ b/MetroscopeModelingLibrary/Tests/SimpleExamples/PowerPlant/MetroscopiaNPP/MetroscopiaNPP_topological.mo
@@ -2,7 +2,7 @@ within MetroscopeModelingLibrary.Tests.SimpleExamples.PowerPlant.MetroscopiaNPP;
 partial model MetroscopiaNPP_topological
   extends Modelica.Icons.Example;
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.OpenSteamGenerator
     steamGenerator

--- a/MetroscopeModelingLibrary/Tests/SimpleExamples/WaterSteam/FlashTank_Reheater.mo
+++ b/MetroscopeModelingLibrary/Tests/SimpleExamples/WaterSteam/FlashTank_Reheater.mo
@@ -2,7 +2,7 @@ within MetroscopeModelingLibrary.Tests.SimpleExamples.WaterSteam;
 model FlashTank_Reheater
   extends Modelica.Icons.Example;
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.CondReheater CondReheater
     annotation (Placement(transformation(extent={{-20,26},{12,42}})));

--- a/MetroscopeModelingLibrary/Tests/SimpleExamples/WaterSteam/MetroscopeTrainingTest.mo
+++ b/MetroscopeModelingLibrary/Tests/SimpleExamples/WaterSteam/MetroscopeTrainingTest.mo
@@ -1,7 +1,7 @@
 within MetroscopeModelingLibrary.Tests.SimpleExamples.WaterSteam;
 model MetroscopeTrainingTest
   extends Modelica.Icons.Example;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   /* --- Boundary Conditions --- */
   input Real W_heater(start = 35);

--- a/MetroscopeModelingLibrary/Tests/UnitTests/Multifluid/HeatExchangers/TestNTUCounterCurrentHeatExchanger.mo
+++ b/MetroscopeModelingLibrary/Tests/UnitTests/Multifluid/HeatExchangers/TestNTUCounterCurrentHeatExchanger.mo
@@ -2,9 +2,9 @@ within MetroscopeModelingLibrary.Tests.UnitTests.Multifluid.HeatExchangers;
 model TestNTUCounterCurrentHeatExchanger
   extends Modelica.Icons.Example;
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package MoistAirMedium =
+  package MoistAirMedium =
       MetroscopeModelingLibrary.MoistAir.Medium.MoistAirMedium;
   MetroscopeModelingLibrary.MoistAir.BoundaryConditions.Source moistAirSource(h_out(
         start=283945), h_vol(start=283945))

--- a/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestCondReheater.mo
+++ b/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestCondReheater.mo
@@ -2,7 +2,7 @@ within MetroscopeModelingLibrary.Tests.UnitTests.WaterSteam.HeatExchangers;
 model TestCondReheater
   extends Modelica.Icons.Example;
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink sink_hot_CondSteam(Q_in(start=60))
     annotation (Placement(transformation(

--- a/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestCondReheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestCondReheater_PartialCondensation.mo
@@ -2,7 +2,7 @@ within MetroscopeModelingLibrary.Tests.UnitTests.WaterSteam.HeatExchangers;
 model TestCondReheater_PartialCondensation
   extends Modelica.Icons.Example;
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.CondReheater_PartialCondensation
                                                                    CondReheater(Q_hot(start=60))

--- a/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestReheater.mo
+++ b/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestReheater.mo
@@ -2,7 +2,7 @@ within MetroscopeModelingLibrary.Tests.UnitTests.WaterSteam.HeatExchangers;
 model TestReheater
   extends Modelica.Icons.Example;
   import MetroscopeModelingLibrary;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Reheater Reheater
     annotation (Placement(transformation(extent={{12,26},{-20,42}})));

--- a/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestSuperheater.mo
+++ b/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestSuperheater.mo
@@ -1,7 +1,7 @@
 within MetroscopeModelingLibrary.Tests.UnitTests.WaterSteam.HeatExchangers;
 model TestSuperheater
   extends Modelica.Icons.Example;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Superheater Superheater
     annotation (Placement(transformation(extent={{-20,26},{12,42}})));

--- a/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestSuperheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/Tests/UnitTests/WaterSteam/HeatExchangers/TestSuperheater_PartialCondensation.mo
@@ -1,7 +1,7 @@
 within MetroscopeModelingLibrary.Tests.UnitTests.WaterSteam.HeatExchangers;
 model TestSuperheater_PartialCondensation
   extends Modelica.Icons.Example;
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Superheater_PartialCondensation Superheater
     annotation (Placement(transformation(extent={{-16,32},{16,48}})));

--- a/MetroscopeModelingLibrary/WaterSteam/BoundaryConditions/LoopCloser.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/BoundaryConditions/LoopCloser.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.BoundaryConditions;
 model LoopCloser
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.BoundaryConditions.LoopCloser(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/BoundaryConditions/Sink.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/BoundaryConditions/Sink.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.BoundaryConditions;
 model Sink
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.BoundaryConditions.Sink(redeclare
       package                                                                        Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/BoundaryConditions/Source.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.BoundaryConditions;
 model Source
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.BoundaryConditions.Source(redeclare
       package                                                                        Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/Functions/VaporMassFraction.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Functions/VaporMassFraction.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Functions;
 function VaporMassFraction
-      replaceable package WaterSteamMedium =
+      package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.Functions.VaporMassFraction( redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondReheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondReheater_PartialCondensation.mo
@@ -1,8 +1,8 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model CondReheater_PartialCondensation
-  replaceable package ColdMedium =
+  package ColdMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package HotMedium =
+  package HotMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondenserSimple.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/CondenserSimple.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model CondenserSimple
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -1,8 +1,8 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model LiqLiqHX
-  replaceable package ColdMedium =
+  package ColdMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package HotMedium =
+  package HotMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/OpenSteamGenerator.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/OpenSteamGenerator.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model OpenSteamGenerator
-  replaceable package water =
+  package Water =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;
@@ -25,19 +25,19 @@ public
         origin={0,48})));
   BoundaryConditions.Sink waterSupplySink
     annotation (Placement(transformation(extent={{22,0},{-18,40}})));
-  Common.Connectors.FluidInlet C_water_in(redeclare package Medium = water)
+  Common.Connectors.FluidInlet C_water_in(redeclare package Medium = Water)
     annotation (Placement(transformation(extent={{36,10},{56,30}})));
-  Common.Connectors.FluidOutlet C_steam_out(redeclare package Medium = water)
+  Common.Connectors.FluidOutlet C_steam_out(redeclare package Medium = Water)
     annotation (Placement(transformation(extent={{-10,90},{10,112}})));
-  Common.Connectors.FluidOutlet C_drain_out(redeclare package Medium = water)
+  Common.Connectors.FluidOutlet C_drain_out(redeclare package Medium = Water)
     annotation (Placement(transformation(extent={{-8,-110},{12,-88}})));
   BoundaryConditions.Source drainSource annotation (Placement(transformation(
         extent={{20,-20},{-20,20}},
         rotation=90,
         origin={0,-42})));
 equation
-  hlsat=water.bubbleEnthalpy(water.setSat_p(drainSource.P_out));
-  hvsat=water.dewEnthalpy(water.setSat_p(steamSource.P_out));
+  hlsat=Water.bubbleEnthalpy(Water.setSat_p(drainSource.P_out));
+  hvsat=Water.dewEnthalpy(Water.setSat_p(steamSource.P_out));
   ThermalPower=-steamSource.Q_out*steamSource.h_out -waterSupplySink.Q_in *
     waterSupplySink.h_in - drainSource.Q_out*drainSource.h_out;
   drainSource.h_out = hlsat;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -1,8 +1,8 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model Reheater
-  replaceable package ColdMedium =
+  package ColdMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package HotMedium =
+  package HotMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater_PartialCondensation.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater_PartialCondensation.mo
@@ -1,8 +1,8 @@
 within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model Superheater_PartialCondensation
-  replaceable package ColdMedium =
+  package ColdMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
-  replaceable package HotMedium =
+  package HotMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;

--- a/MetroscopeModelingLibrary/WaterSteam/Junctions/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Junctions/SteamDryer.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Junctions;
 model SteamDryer
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   Modelica.Units.SI.MassFlowRate Q_in(start=4000) "Inlet Mass flow rate";
   Modelica.Units.SI.AbsolutePressure P_in(start=71e5) "Inlet Pressure";

--- a/MetroscopeModelingLibrary/WaterSteam/Junctions/SteamExtractionSplitter.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Junctions/SteamExtractionSplitter.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Junctions;
 model SteamExtractionSplitter
-  replaceable package WaterSteamMedium =
+  package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
 
   connector InputReal = input Real;

--- a/MetroscopeModelingLibrary/WaterSteam/Machines/StaticCentrifugalPump.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Machines/StaticCentrifugalPump.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Machines;
 model StaticCentrifugalPump
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.Machines.StaticCentrifugalPump(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/Machines/StodolaTurbine.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Machines/StodolaTurbine.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Machines;
 model StodolaTurbine
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
     extends MetroscopeModelingLibrary.Common.Partial.BasicTransportModel(P_in(start=60e5), P_out(start=55e5),h_in(start=2.7e6), h_out(start=2.6e6), redeclare package
               Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/PressureLosses/ControlValve.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/PressureLosses/ControlValve.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.PressureLosses;
 model ControlValve
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.PressureLosses.ControlValve(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/PressureLosses/PipePressureLoss.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/PressureLosses/PipePressureLoss.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.PressureLosses;
 model PipePressureLoss "Pipe generic pressure loss"
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.PressureLosses.PipePressureLoss(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/PressureLosses/PressureCut.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/PressureLosses/PressureCut.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.PressureLosses;
 model PressureCut
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.PressureLosses.PressureCut(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/PressureLosses/SingularPressureAndHeatLoss.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/PressureLosses/SingularPressureAndHeatLoss.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.PressureLosses;
 model SingularPressureAndHeatLoss
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends
     MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureAndHeatLoss(      redeclare

--- a/MetroscopeModelingLibrary/WaterSteam/PressureLosses/SingularPressureLoss.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/PressureLosses/SingularPressureLoss.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.PressureLosses;
 model SingularPressureLoss
-   replaceable package WaterSteamMedium =
+   package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Common.PressureLosses.SingularPressureLoss(redeclare
       package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/Sensors/MassFlowWater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Sensors/MassFlowWater.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Sensors;
 model MassFlowWater
-    replaceable package WaterSteamMedium =
+    package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
           extends MetroscopeModelingLibrary.Common.Sensors.MassFlowSensor(
                                                       redeclare package Medium =

--- a/MetroscopeModelingLibrary/WaterSteam/Sensors/PressureDifferenceWater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Sensors/PressureDifferenceWater.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Sensors;
 model PressureDifferenceWater
-      replaceable package WaterSteamMedium =
+      package WaterSteamMedium =
       MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
     extends
     MetroscopeModelingLibrary.Common.Sensors.PressureDifferenceSensor(    redeclare package

--- a/MetroscopeModelingLibrary/WaterSteam/Sensors/PressureWater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Sensors/PressureWater.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Sensors;
 model PressureWater
-    replaceable package WaterSteamMedium =
+    package WaterSteamMedium =
     MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
     extends
     MetroscopeModelingLibrary.Common.Sensors.PressureSensor(            redeclare package

--- a/MetroscopeModelingLibrary/WaterSteam/Sensors/TemperatureWater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Sensors/TemperatureWater.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.WaterSteam.Sensors;
 model TemperatureWater
-    replaceable package WaterSteamMedium =
+    package WaterSteamMedium =
     MetroscopeModelingLibrary.WaterSteam.Medium.WaterSteamMedium;
     extends MetroscopeModelingLibrary.Common.Sensors.TemperatureSensor( redeclare package
               Medium = WaterSteamMedium);


### PR DESCRIPTION
This PR removes the "replaceable" keyword from the following fluids:
- water
- FlueGasesMedium
- FuelMedium
- MoistAirMedium
- WaterSteamMedium

Regarding the media:
- ColdMedium
- HotMedium

The "replaceable" keyword has been removed only where the default medium is one of the media listed above.