### PR TITLE
inherited from keeping scale icon in connectors, BCs and pump

### DIFF
--- a/MetroscopeModelingLibrary/Icons/BoundaryConditions/PowerSinkIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/BoundaryConditions/PowerSinkIcon.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Icons.BoundaryConditions;
 partial record PowerSinkIcon
-  extends Icons.KeepingScaleIcon;
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Ellipse(
           extent={{-40,60},{80,-60}},

--- a/MetroscopeModelingLibrary/Icons/BoundaryConditions/PowerSourceIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/BoundaryConditions/PowerSourceIcon.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Icons.BoundaryConditions;
 partial record PowerSourceIcon
-  extends Icons.KeepingScaleIcon;
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Ellipse(
           extent={{-80,60},{40,-60}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/FluidInletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/FluidInletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record FluidInletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/FluidOutletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/FluidOutletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record FluidOutletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/MoistAirInletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/MoistAirInletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record MoistAirInletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/MoistAirOutletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/MoistAirOutletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record MoistAirOutletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/PowerInletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/PowerInletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record PowerInletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/PowerOutletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/PowerOutletIcon.mo
@@ -1,6 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record PowerOutletIcon
-  extends Icons.KeepingScaleIcon;
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/WaterInletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/WaterInletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record WaterInletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Connectors/WaterOutletIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Connectors/WaterOutletIcon.mo
@@ -1,5 +1,6 @@
 within MetroscopeModelingLibrary.Icons.Connectors;
 partial record WaterOutletIcon
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (Icon(graphics={
         Rectangle(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Icons/Machines/PumpIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Machines/PumpIcon.mo
@@ -1,9 +1,8 @@
 within MetroscopeModelingLibrary.Icons.Machines;
 partial record PumpIcon
-  extends Icons.KeepingScaleIcon;
+  extends MetroscopeModelingLibrary.Icons.KeepingScaleIcon;
   annotation (
     Diagram(coordinateSystem(
-        preserveAspectRatio=true,
         extent={{-100,-100},{100,100}},
         grid={2,2}), graphics={
         Ellipse(
@@ -15,7 +14,6 @@ partial record PumpIcon
         Line(points={{80,0},{2,60}}),
         Line(points={{80,0},{0,-60}})}),
     Icon(coordinateSystem(
-        preserveAspectRatio=true,
         extent={{-100,-100},{100,100}},
         grid={2,2}), graphics={
         Ellipse(


### PR DESCRIPTION
Inherited KeepingScaleIcon in connectors, BCs and pump

Fixes #94 

Signed-off-by: pepmts <pierre-elie.personnaz@metroscope.tech>