### PR TITLE
added Q and T start values

### DIFF
--- a/MetroscopeModelingLibrary/Examples/NuclearPowerPlant/MetroscopiaNPP/Metroscopia_NPP_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/NuclearPowerPlant/MetroscopiaNPP/Metroscopia_NPP_reverse.mo
@@ -197,7 +197,7 @@ model Metroscopia_NPP_reverse
         origin={58,-46})));
     Sensors.WaterSteam.WaterTemperatureSensor HP_pump_T_out_sensor annotation (Placement(transformation(extent={{36,-77},{22,-63}})));
     Sensors.WaterSteam.WaterPressureSensor HP_pump_P_out_sensor annotation (Placement(transformation(extent={{7,-7},{-7,7}}, origin={1,-70})));
-  WaterSteam.HeatExchangers.Reheater HP_reheater annotation (Placement(transformation(extent={{-20,-78},{-52,-62}})));
+  WaterSteam.HeatExchangers.Reheater HP_reheater(Q_cold_0=1500, Q_hot_0=50) annotation (Placement(transformation(extent={{-20,-78},{-52,-62}})));
   Sensors.WaterSteam.WaterTemperatureSensor HP_reheater_T_cold_out_sensor annotation (Placement(transformation(extent={{-80,-77},{-94,-63}})));
   Sensors.WaterSteam.WaterPressureSensor HP_reheater_P_cold_out_sensor annotation (Placement(transformation(extent={{-60,-77},{-74,-63}})));
     Sensors.WaterSteam.WaterTemperatureSensor HP_reheater_T_drains_sensor annotation (Placement(transformation(

--- a/MetroscopeModelingLibrary/Icons/Sensors/PowerSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Icons/Sensors/PowerSensorIcon.mo
@@ -7,8 +7,7 @@ partial record PowerSensorIcon "should be extended in partial base classes"
           extent={{-100,100},{100,-98}},
           lineColor={0,0,0},
           fillColor={244,125,35},
-          fillPattern=FillPattern.Solid,
-          lineThickness=0.5),
+          fillPattern=FillPattern.Solid),
         Ellipse(
           extent={{-80,81},{80,-79}},
           fillColor={255,255,255},

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
@@ -20,14 +20,16 @@ model DryReheater
 
   Units.InletMassFlowRate Q_cold(start=Q_cold_0, nominal=Q_cold_0, min=1e-5);
   Units.InletMassFlowRate Q_hot(start=Q_hot_0, nominal=Q_hot_0);
-  Units.Temperature T_cold_in;
+  Units.Temperature T_cold_in(start=T_cold_in_0);
   Units.Temperature T_cold_out;
-  Units.Temperature T_hot_in;
+  Units.Temperature T_hot_in(start=T_hot_in_0);
   Units.Temperature T_hot_out;
 
   // Initialization parameters
   parameter Units.MassFlowRate Q_cold_0 = 500;
   parameter Units.MassFlowRate Q_hot_0 = 50;
+  parameter Units.Temperature T_hot_in_0 = 273.15 + 200;
+  parameter Units.Temperature T_cold_in_0 = 273.15 + 50;
 
   Connectors.Inlet C_cold_in(Q(start=Q_cold_0)) annotation (Placement(transformation(extent={{-172,-10},{-152,10}}), iconTransformation(extent={{-172,-10},{-152,10}})));
   Connectors.Inlet C_hot_in(Q(start=Q_hot_0)) annotation (Placement(transformation(extent={{-10,70},{10,90}}), iconTransformation(extent={{-10,70},{10,90}})));
@@ -49,7 +51,8 @@ model DryReheater
         rotation=180,
         origin={-59,21})));
   BaseClasses.IsoPFlowModel cold_side_condensing(Q_0=Q_cold_0) annotation (Placement(transformation(extent={{-82,-58},{-34,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
+                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={-60,0})));

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -30,19 +30,21 @@ model Reheater
   Units.Temperature Tsat;
 
   parameter String HX_config_condensing="condenser_counter_current";
-  parameter String HX_config_subcooling= "shell_and_tubes";
+  parameter String HX_config_subcooling="shell_and_tubes";
   parameter String QCp_max_side_subcooling = "cold";
 
   Units.InletMassFlowRate Q_cold(start=Q_cold_0, nominal=Q_cold_0);
   Units.InletMassFlowRate Q_hot(start=Q_hot_0, nominal=Q_hot_0);
-  Units.Temperature T_cold_in;
+  Units.Temperature T_cold_in(start=T_cold_in_0);
   Units.Temperature T_cold_out;
   Units.Temperature T_hot_in;
-  Units.Temperature T_hot_out;
+  Units.Temperature T_hot_out(start=T_hot_in_0);
 
   // Initialization parameters
   parameter Units.MassFlowRate Q_cold_0 = 500;
   parameter Units.MassFlowRate Q_hot_0 = 50;
+  parameter Units.Temperature T_hot_in_0 = 273.15 + 200;
+  parameter Units.Temperature T_cold_in_0 = 273.15 + 50;
 
   Connectors.Inlet C_cold_in(Q(start=Q_cold_0)) annotation (Placement(transformation(extent={{-172,-10},{-152,10}}), iconTransformation(extent={{-172,-10},{-152,10}})));
   Connectors.Inlet C_hot_in(Q(start=Q_hot_0)) annotation (Placement(transformation(extent={{-10,70},{10,90}}), iconTransformation(extent={{-10,70},{10,90}})));
@@ -64,7 +66,8 @@ model Reheater
         rotation=180,
         origin={23,19})));
   BaseClasses.IsoPFlowModel cold_side_condensing(Q_0=Q_cold_0) annotation (Placement(transformation(extent={{0,-58},{48,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config_condensing) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config_condensing, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
+                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={24,-6})));
@@ -73,7 +76,8 @@ model Reheater
         rotation=180,
         origin={-55,19})));
   BaseClasses.IsoPFlowModel cold_side_subcooling(Q_0=Q_cold_0) annotation (Placement(transformation(extent={{-78,-58},{-30,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX_subcooling(config=HX_config_subcooling, QCp_max_side = QCp_max_side_subcooling)
+  Power.HeatExchange.NTUHeatExchange HX_subcooling(config=HX_config_subcooling, QCp_max_side=QCp_max_side_subcooling, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
+                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0)
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/SuperHeater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/SuperHeater.mo
@@ -33,15 +33,17 @@ model SuperHeater
   // Definitions
   Units.InletMassFlowRate Q_cold(start=Q_cold_0, nominal=Q_cold_0, min=1e-5);
   Units.InletMassFlowRate Q_hot(start=Q_hot_0, nominal=Q_hot_0);
-  Units.Temperature T_cold_in;
+  Units.Temperature T_cold_in(start=T_cold_in_0);
   Units.Temperature T_cold_out;
-  Units.Temperature T_hot_in;
+  Units.Temperature T_hot_in(start=T_hot_in_0);
   Units.Temperature T_hot_out;
   Units.Power W_tot;
 
   // Initialization parameters
   parameter Units.MassFlowRate Q_cold_0 = 500;
   parameter Units.MassFlowRate Q_hot_0 = 50;
+  parameter Units.Temperature T_hot_in_0 = 273.15 + 220;
+  parameter Units.Temperature T_cold_in_0 = 273.15 + 100;
 
   Connectors.Inlet C_cold_in(Q(start=Q_cold_0)) annotation (Placement(transformation(extent={{-10,-90},{10,-70}}), iconTransformation(extent={{-10,-90},{10,-70}})));
   Connectors.Inlet C_hot_in(Q(start=Q_hot_0)) annotation (Placement(transformation(extent={{-170,-8},{-150,12}}), iconTransformation(extent={{-170,-8},{-150,12}})));
@@ -72,7 +74,8 @@ model SuperHeater
         extent={{-17,-17},{17,17}},
         rotation=90,
         origin={39,1})));
-  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
+                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-21},{10,21}},
         rotation=270,
         origin={3,2})));


### PR DESCRIPTION
Added first set of start values with Q and T, propagating all start values in NTU HX from water steam HX.

It is working but some other start values could be propagated through components
Start values are not yet added to LiqLiqHX

Signed-off-by: pepmts <pierre-elie.personnaz@metroscope.tech>