### PR TITLE
removed and replaced old todo list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,51 @@
-# TODO List
+# Metroscope Modeling Library
 
-- [x] Setup Git
-    - [x] Créer la branche mml3-main
-    - [x] Créer CHANGELOG.md
-    - [x] Créer template PullRequest
-    - [x] Créer template Issues
-- [x] Ecrire Units
-- [x] Connecteurs + PartialTransportModel + BaseClasses (non medium-specific)
-    - [x] Connecteurs
-    - [x] PartialTransportModel
-    - [x] BaseClasses (non medium-specific)
-- [x] BoundaryConditions
-- [x] Créer Medium.WaterSteam, hériter les premières classes.
-- [x] Sensors
-- [x] Créer Tests
-- [x] Créer MoistAir et vérifier que le x est bien traité
-- [x] Construire Pipes + Tests
-    - [x] Partial.Pipes
-    - [x] WaterSteam.Pipe
-- [ ] Autres types de composants + Tests
-- [ ] Examples
-    - [ ] Metroscopia
-    - [ ] MetroscopiaCCGT ?
-    - [ ] GasTurbine
-    - [ ] ParallelFWP
-    - [ ] FlashTank_Reheater
-    - [ ] TurbineLine
+## Content
 
-# Workflow
+ The Metroscope Modeling Library contains modelica modules for industrial components such as pumps, turbines, heat exchangers, to build steady-state digital twins of industrial process. The associated documentation contains explanation of the library equations. 
 
-1. Créer une branche
-2. Créer une sousbranche par composant
-3. Mettre à jour le changelog
-4. PR
+## Usage
+
+- When creating a Digital Twin (also called model or even `Parametrization` in license file), you should only use official releases of `Metroscope Modeling Library`. Official releases can be downloaded from [here](https://github.com/Metroscope-dev/metroscope-modeling-library/releases).
+
+## Reporting a bug
+
+- Report your issues on [issues page](https://github.com/Metroscope-dev/metroscope-modeling-library/issues)
+- Do not attach sensitive data to the GitHub issue you create
+- Provide following information
+  - A clear and concise description of what the bug is
+  - Steps to reproduce the bahavior
+  - A clear and concise description of what you expected to happen.
+  - Your configuration (OS, Modelica version, Metroscope Modeling Library version, modeling software & version)
+
+## Contributions
+
+Your contributions are very welcome. To contribute, you have to clone repository `Metroscope Modeling Library`: `git clone git@github.com:Metroscope-dev/metroscope-modeling-library.git`
+
+To suggest changes, you have to:
+- checkout main branch: `git checkout master`
+- pull last changes: `git pull`
+- create a new branch: `git checkout -b new-branch-name`
+- commit your changes & push your code
+- [create a pull request](https://github.com/Metroscope-dev/metroscope-modeling-library/pulls)
+  - Give a meaningfule title to your pull request (examples: `BUG FIX - Stodola Turbine` or `NEW COMPONENT - <NEW_COMPONENT_NAME>`)
+  - Provide a comment explaining the changes
+    - Aim of the changes
+    - Description of the changes
+    - If associated to an open GitHub issue, provide its url
+
+For the sake of efficiency, create a draft pull request if you still have work to do before having your pull request reviewed ([see Github documentation if needed](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)).
+
+When your pull request is ready for review, change its stage ([see documentation if needed](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request)) and notify the `#physical-modeling` slack channel Your pull request will be reviewed; if validated, it will be merged on main branch by Metroscope.
+
+## License
+
+License file is [Metroscope Contributor License Agreement For MML](Metroscope_contributor_license_agreement_for_mml.docx)
+
+## Attribution notices
+
+Copyright 2021 Metroscope
+
+Metroscope Modeling Library is a Derivative Work of ThermoSysPro:
+- [ThermoSysPro home page](https://thermosyspro.com)
+- [ThermoSysPro license](https://github.com/ThermoSysPro/ThermoSysPro/blob/master/LICENSE.md)


### PR DESCRIPTION
## Goal

Remove the old readme that was a todo list of MML3 building
Replaced by `main` readme

## Type of change

- [ ] Bugfix (non-breaking change which fixes a bug/issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which reorganizes code)
- [ ] Release & Version Update (when cumulative changes justify a release)
- [x] Documentation Update

## Checklist

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.

GitHub checks:

- [x] I have added the appropriate tags, reviewers, projects and linked issues to this PR
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

Model development checks:

- [x] I have performed a self-review of my own code
- [x] **I have checked that my changes do not bring any retrocompatibility issue comparing to [MML3-DTG-v3](https://github.com/Metroscope-dev/metroscope-modeling-library/releases/tag/MML3-DTG-v3) version**
- [x] Existing tests pass (including Metroscopia !).
- [x] I have added/updated tests that prove my development works and does not break anything.

Library checks:

- [x] I have checked in the file explorer that I am not adding duplicate file/folder/package (due to renaming or moving file/package)
- [x] I have checked that the packages I upload are stored as separate files

Documentation checks:

- [x] I have made corresponding changes or additions to the documentation
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
