### PR TITLE
Fuel source molar fraction

### DIFF
--- a/MetroscopeModelingLibrary/Fuel/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/Fuel/BoundaryConditions/Source.mo
@@ -19,20 +19,20 @@ model Source
   Real amN2 "H2O molecular mass";
 
   // Fuel composition
-  Units.MassFraction X_fuel_CH4(start=0.848);
-  Units.MassFraction X_fuel_C2H6(start=0.083);
-  Units.MassFraction X_fuel_C3H8(start=0.0126);
-  Units.MassFraction X_fuel_C4H10_n_butane(start=0.00668);
-  Units.MassFraction X_fuel_N2(start=0.024);
-  Units.MassFraction X_fuel_CO2(start=0.025);
+  Units.MassFraction X_CH4(start=0.848);
+  Units.MassFraction X_C2H6(start=0.083);
+  Units.MassFraction X_C3H8(start=0.0126);
+  Units.MassFraction X_C4H10_n_butane(start=0.00668);
+  Units.MassFraction X_N2(start=0.024);
+  Units.MassFraction X_CO2(start=0.025);
 
   // Mole fractions
-  Real X_molar_fuel_CH4(start=0.92);
-  Real X_molar_fuel_C2H6(start=0.048);
-  Real X_molar_fuel_C3H8(start=0.005);
-  Real X_molar_fuel_C4H10_n_butane(start=0.002);
-  Real X_molar_fuel_N2(start=0.015);
-  Real X_molar_fuel_CO2(start=0.01);
+  Real X_molar_CH4(start=0.92);
+  Real X_molar_C2H6(start=0.048);
+  Real X_molar_C3H8(start=0.005);
+  Real X_molar_C4H10_n_butane(start=0.002);
+  Real X_molar_N2(start=0.015);
+  Real X_molar_CO2(start=0.01);
 
   // Mean molecular mass
   Real mean_molecular_mass(start=17);
@@ -49,22 +49,22 @@ equation
 
 
   // Composition mass fraction
-  X_fuel_CH4 = Xi_out[1]; // methane
-  X_fuel_C2H6 = Xi_out[2]; // ethane
-  X_fuel_C3H8=  Xi_out[3]; // propane
-  X_fuel_C4H10_n_butane=  Xi_out[4]; // butane
-  X_fuel_N2=  Xi_out[5]; // nitrogen
-  X_fuel_CO2=  Xi_out[6]; // carbon dioxyde
+  X_CH4 = Xi_out[1]; // methane
+  X_C2H6 = Xi_out[2]; // ethane
+  X_C3H8 = Xi_out[3]; // propane
+  X_C4H10_n_butane = Xi_out[4]; // butane
+  X_N2 = Xi_out[5]; // nitrogen
+  X_CO2 = Xi_out[6]; // carbon dioxyde
 
   // Mean Molecular Mass: this gives the correct results only if the molar fraction is given as an input, if the mass fraction is given, this quantity is useless
-  mean_molecular_mass = X_molar_fuel_CH4*amCH4 + X_molar_fuel_C2H6*amC2H6 + X_molar_fuel_C3H8*amC3H8 + X_molar_fuel_C4H10_n_butane*amC4H10 + X_molar_fuel_N2*amN2 + X_molar_fuel_CO2*amCO2;
+  mean_molecular_mass = X_molar_CH4*amCH4 + X_molar_C2H6*amC2H6 + X_molar_C3H8*amC3H8 + X_molar_C4H10_n_butane*amC4H10 + X_molar_N2*amN2 + X_molar_CO2*amCO2;
 
   // Mass and mole fraction relation
-  X_molar_fuel_CH4 = X_fuel_CH4/amCH4 * mean_molecular_mass;
-  X_molar_fuel_C2H6 = X_fuel_C2H6/amC2H6 * mean_molecular_mass;
-  X_molar_fuel_C3H8 = X_fuel_C3H8/amC3H8 * mean_molecular_mass;
-  X_molar_fuel_C4H10_n_butane = X_fuel_C4H10_n_butane/amC4H10 * mean_molecular_mass;
-  X_molar_fuel_N2 = X_fuel_N2/amN2 * mean_molecular_mass;
-  X_molar_fuel_CO2 = X_fuel_CO2/amCO2 * mean_molecular_mass;
+  X_molar_CH4 = X_CH4/amCH4 * mean_molecular_mass;
+  X_molar_C2H6 = X_C2H6/amC2H6 * mean_molecular_mass;
+  X_molar_C3H8 = X_C3H8/amC3H8 * mean_molecular_mass;
+  X_molar_C4H10_n_butane = X_C4H10_n_butane/amC4H10 * mean_molecular_mass;
+  X_molar_N2 = X_N2/amN2 * mean_molecular_mass;
+  X_molar_CO2 = X_CO2/amCO2 * mean_molecular_mass;
 
 end Source;

--- a/MetroscopeModelingLibrary/Tests/Fuel/BoundaryConditions/Source.mo
+++ b/MetroscopeModelingLibrary/Tests/Fuel/BoundaryConditions/Source.mo
@@ -19,12 +19,12 @@ equation
   // source.Xi_out = {0.92,0.048,0.005,0.002,0.015,0.01};
 
   // Molar fraction as input
-  source.X_molar_fuel_CH4=0.92;
-  source.X_molar_fuel_C2H6=0.048;
-  source.X_molar_fuel_C3H8=0.005;
-  source.X_molar_fuel_C4H10_n_butane=0.002;
-  source.X_molar_fuel_N2=0.015;
-  source.X_molar_fuel_CO2=0.01;
+  source.X_molar_CH4=0.92;
+  source.X_molar_C2H6=0.048;
+  source.X_molar_C3H8=0.005;
+  source.X_molar_C4H10_n_butane=0.002;
+  source.X_molar_N2=0.015;
+  source.X_molar_CO2=0.01;
 
 
 


### PR DESCRIPTION
## Goal

Solves issue #307 : The ability to give the fuel source the molar fraction instead of the mass fraction as input

## Type of change

Add a conversion equation in the fuel source based on the mean molar mass of the fuel mixture.
⚠️ The conversion from mass fraction to molar fraction is not possible. It is not needed.

## Checklist

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.

- [x] I have added the appropriate tags, reviewers, projects and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] Existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [ ] I have checked for conflicts with target branch, and merged/rebased in consequence