### PR TITLE
Correction of the isentropic state of the compressor

### DIFF
--- a/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
@@ -34,7 +34,7 @@ equation
   C_W_in.W =  Wmech;
 
   /* Isentropic compression */
-  state_is =  Medium.setState_psX(P_out, Medium.specificEntropy(state_in));
+  state_is =  Medium.setState_psX(P_out, Medium.specificEntropy(state_in),Xi);
   h_is = Medium.specificEnthalpy(state_is);
 
 


### PR DESCRIPTION
Signed-off-by: Nabil Youssef <nabil.youssef@metroscope.tech>

## Goal

Fixing an error in the `AirCompressor`: the isentropic state at the outlet of the compressor wasn't taking into account the actual composition of the air. Therefore, by default, the reference state was considered while calculating the isentropic enthalpy, causing wrong calculation of the isentropic efficiency of the compressor.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release & Version Update (when cumulative changes justify a release)
- [ ] Documentation Update

## Checklist

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.

- [x] I have added the appropriate tags, reviewers, projects and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] Existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [ ] I have checked for conflicts with target branch, and merged/rebased in consequence