### PR TITLE
Bump to v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added <!--Make sure to add a link to the PR and issues related to your change-->
 
+### Fixed <!--Make sure to add a link to the PR and issues related to your change-->
+
+### Changed <!--Make sure to add a link to the PR and issues related to your change-->
+
+### Removed <!--Make sure to add a link to the PR and issues related to your change-->
+
+
+## MML-v3.1 <!--Make sure to add a link to the PR and issues related to your change-->
+
+### Added <!--Make sure to add a link to the PR and issues related to your change-->
+
 - Added internal leaks in DryReheater, Reheater and SuperHeater [PR#306](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/306)
 - Added units in leaks [PR#314](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/314)
 - Added an air cooled condenser for CCGT modeling in [PR#305](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/305)


### PR DESCRIPTION
## Goal

I have updated the changelog with all the missing entries from previous PRs

@nabilgyoussef I'll let you complete the CCGT section with your modifications on CCGT side

## Proposed Release notes

Some minor changes not written here are detailed in [Changelog](https://github.com/Metroscope-dev/metroscope-modeling-library/blob/bump-to-v3.1/CHANGELOG.md#mml-v31-)

### Common changes

- Pumps do not have an `adiabatic_compression` option anymore
### NPP specific

- All heaters leaks are now modeled inside the heater, meaning that you have to specify `heater.tube_rupture.Q` if `heater` is declared with `faulty=true` parameter, see #306. The same is true for all heaters in `WaterSteam.HeatExchanger` package
- Leaks can now have non-SI units after #314, to which you can have access in the same way as you do with sensors

-> If you maintain a client model and want to use this version, you will have to modify the faulty model only, by removing all the internal heaters leaks (tube rupture and separating plate leak), and assign variables to internal variables defined

### CCGT specific 

- The isentropic state in the `AirCompressor` component have been corrected: models of previous versions should be adapted for compatibility. The isentropic efficiency's order of magnitude changed: calibrated efficiency with the previous version of the library will definitely give wrong values for the outlet temperature and power consumption of the compressor #311 
- The `NTUHeatExchange` now have the counter current flow configuration. Moreover, it is now possible not to predefine the `QCpMAX` side: the model can check by itself. #304 
- The `Source` of the `FuelMedium` can now accept the molar fraction of the composition instead of the mass fraction: the conversion is made directly in the component. #309 
- The `CombustionChamber` can now calculate the LHV and HHV from the composition. However, if the LHV or HHV are given, it can be assigned in the modifier of the `CombustionChamber` component. #310 

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Release & Version Update (when cumulative changes justify a release)
- [ ] Documentation Update

## Checklist

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.

- [ ] I have added the appropriate tags, reviewers, projects and linked issues to this PR
- [ ] I have performed a self-review of my own code
- [ ] Existing tests pass.
- [ ] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [ ] I have checked for conflicts with target branch, and merged/rebased in consequence