### PR TITLE
separated breaking types of changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,11 +7,15 @@ If it fixes an issue, mention the issue using closing key words ([how to do that
 
 ## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->
 
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Refactoring change (non-breaking change which does not add functionality)
-- [ ] Release & Version Update (resulting in a change of the version number in `package.mo`)
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Refactoring change
+- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)
 
+Will it break anything in previous models ?
+
+- [ ] Breaking change (If yes, make sure to point it out in the changelog)
+- [ ] Non-Breaking change
 
 ## Checklist
 


### PR DESCRIPTION
## Goal

I modified PR template to make sure we question about breaking or non breaking change, and put that in the changelog.


## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring change (non-breaking change which does not add functionality)
- [ ] Release & Version Update (resulting in a change of the version number in `package.mo`)


## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [ ] I have checked that all existing tests pass.
- [ ] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
