### PR TITLE
HX indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 ### :sparkles: Added <!--Make sure to add a link to the PR and issues related to your change-->
 
 -  ✨ Add and correct initialization parameters in flue gases [#436](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/436/files)
+-  ✨ Add indicators in the HX models
 
 ### :bug: Fixed <!--Make sure to add a link to the PR and issues related to your change-->
 - :wrench: Initialisation parameters and unit tests of the multifluid heat exchangers fix for a better convergence

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
@@ -589,7 +589,7 @@ equation
   pumpRec_controlValve.Cv_max = pumpRec_CV_Cvmax;
 
   connect(HPsuperheater1.C_cold_out, T_w_HPSH1_out_sensor.C_in) annotation (
-     Line(points={{-165,-5},{-166,-5},{-166,8},{-178,8}}, color={28,108,200}));
+     Line(points={{-168,-2},{-166,-2},{-166,8},{-178,8}}, color={28,108,200}));
   connect(P_HPST_out_sensor.C_in, HPsteamTurbine.C_out)
     annotation (Line(points={{-114,148},{-126,148}}, color={28,108,200}));
   connect(P_HPST_in_sensor.C_out, HPsteamTurbine.C_in)
@@ -605,39 +605,39 @@ equation
   connect(compressor_T_out_sensor.C_out,combustionChamber. inlet) annotation (Line(points={{-460,
           -26},{-452,-26}},                                                                                  color={95,95,95}));
   connect(evaporator.C_cold_in, T_w_eco_out_sensor.C_out) annotation (Line(
-        points={{-8.3,-4.575},{-8.3,8},{2,8}},                 color={28,108,200}));
+        points={{-5.4,-1.55},{-5.4,8},{2,8}},                  color={28,108,200}));
   connect(condenser.C_cold_out, T_circulating_water_out_sensor.C_in)
-    annotation (Line(points={{71.6,159},{74,159},{74,158},{78,158},{78,176},{86,
-          176}},    color={28,108,200}));
+    annotation (Line(points={{71.6,159},{74,159},{74,158},{78,158},{78,176},{86,176}},
+                    color={28,108,200}));
   connect(condenser.C_hot_out, pump.C_in) annotation (Line(points={{52,144.778},{52,131},{109,131}},
                               color={28,108,200}));
   connect(powerSource.C_out, pump.C_power)
     annotation (Line(points={{116,145.2},{116,138.56}},
                                                    color={244,125,35}));
   connect(HPsuperheater1.C_cold_in, P_w_evap_out_sensor.C_out) annotation (Line(
-        points={{-147,-5},{-147,8},{-46,8}},  color={28,108,200}));
+        points={{-144,-2},{-144,8},{-46,8}},  color={28,108,200}));
   connect(evaporator.C_cold_out, P_w_evap_out_sensor.C_in) annotation (Line(
-        points={{-25.7,-4.575},{-24,-4.575},{-24,8},{-34,8}},
+        points={{-28.6,-1.55},{-24,-1.55},{-24,8},{-34,8}},
                                                         color={28,108,200}));
   connect(economiser.C_cold_out, P_w_eco_out_sensor.C_in) annotation (Line(
-        points={{94.3,-5.85},{94,-5.85},{94,8},{62,8}},
+        points={{91.4,-2.9},{94,-2.9},{94,8},{62,8}},
                                                    color={28,108,200}));
-  connect(evaporator.C_hot_out, economiser.C_hot_in) annotation (Line(points={{3.3,
-          -26.355},{51,-26.355},{51,-26.5},{82.7,-26.5}},color={95,95,95}));
+  connect(evaporator.C_hot_out, economiser.C_hot_in) annotation (Line(points={{12,-25.75},{51,-25.75},{51,-26.5},{74,-26.5}},
+                                                         color={95,95,95}));
   connect(gasTurbine.C_out, turbine_T_out_sensor.C_in)
     annotation (Line(points={{-382,-26},{-370,-26}}, color={95,95,95}));
   connect(turbine_P_out_sensor.C_in, turbine_T_out_sensor.C_out)
     annotation (Line(points={{-350,-26},{-358,-26}}, color={95,95,95}));
-  connect(evaporator.C_hot_in, Reheater.C_hot_out) annotation (Line(points={{-37.3,
-          -26.355},{-37.3,-26},{-51,-26}}, color={95,95,95}));
+  connect(evaporator.C_hot_in, Reheater.C_hot_out) annotation (Line(points={{-46,-25.75},{-46,-26},{-42,-26}},
+                                           color={95,95,95}));
   connect(HPsuperheater1.C_hot_out, Reheater.C_hot_in)
-    annotation (Line(points={{-135,-26},{-93,-26}}, color={95,95,95}));
+    annotation (Line(points={{-126,-26},{-102,-26}},color={95,95,95}));
   connect(Reheater.C_cold_out, T_w_ReH_out_sensor.C_in)
-    annotation (Line(points={{-81,-5},{-80,-5},{-80,23}}, color={28,108,200}));
+    annotation (Line(points={{-84,-2},{-80,-2},{-80,23}}, color={28,108,200}));
   connect(P_Cond_sensor.C_in, LPsteamTurbine.C_out)
     annotation (Line(points={{28,214},{20,214}},   color={28,108,200}));
-  connect(P_Cond_sensor.C_out, condenser.C_hot_in) annotation (Line(points={{40,214},
-          {52,214},{52,177.134}},    color={28,108,200}));
+  connect(P_Cond_sensor.C_out, condenser.C_hot_in) annotation (Line(points={{40,214},{52,214},{52,177.134}},
+                                     color={28,108,200}));
 
   connect(P_source_air_sensor.C_out, T_source_air_sensor.C_in)
     annotation (Line(points={{-624,-26},{-618,-26}}, color={95,95,95}));
@@ -682,7 +682,7 @@ equation
           {74,48.5455},{74,8},{62,8}},
                                    color={28,108,200}));
   connect(economiser.C_cold_in, T_w_eco_in_sensor.C_out) annotation (Line(
-        points={{111.7,-5.85},{111.7,9},{140,9}},
+        points={{114.6,-2.9},{114.6,9},{140,9}},
                                               color={28,108,200}));
   connect(T_w_eco_in_sensor.C_in, loopBreaker.C_out) annotation (Line(points={{150,9},
           {150,8},{182,8},{182,18}},   color={28,108,200}));
@@ -693,8 +693,8 @@ equation
       Line(points={{120,48.5455},{126,48.5455}},                         color={
           28,108,200}));
   connect(Q_pumpRec_out_sensor.C_out, pumpRec_controlValve.C_in)
-    annotation (Line(points={{150,48.5455},{154,48.5455},{154,48.5455},{157,
-          48.5455}},                                     color={28,108,200}));
+    annotation (Line(points={{150,48.5455},{154,48.5455},{154,48.5455},{157,48.5455}},
+                                                         color={28,108,200}));
   connect(flue_gas_sink.C_in, P_flue_gas_sink_sensor.C_out)
     annotation (Line(points={{222,193},{222,178}}, color={95,95,95}));
   connect(sink.C_in, W_ST_out_sensor.C_out)
@@ -727,8 +727,8 @@ equation
       points={{20,227.44},{20,256},{56.08,256}},
       color={244,125,35},
       smooth=Smooth.Bezier));
-  connect(pumpRec_controlValve.C_out, loopBreaker.C_in) annotation (Line(points={{170,
-          48.5455},{174,48.5455},{174,50},{182,50},{182,38}},   color={28,108,200}));
+  connect(pumpRec_controlValve.C_out, loopBreaker.C_in) annotation (Line(points={{170,48.5455},{174,48.5455},{174,50},{182,50},{182,38}},
+                                                                color={28,108,200}));
   connect(pumpRec.C_out, T_pumpRec_out_sensor.C_in) annotation (Line(points={{101,
           48.5455},{110,48.5455}},             color={28,108,200}));
   connect(AirFilter.C_out, P_filter_out_sensor.C_in)
@@ -738,24 +738,24 @@ equation
   connect(P_filter_out_sensor.C_out, airCompressor.C_in)
     annotation (Line(points={{-536,-26},{-524,-26}}, color={95,95,95}));
   connect(HPsuperheater1.C_hot_in, HPsuperheater2.C_hot_out)
-    annotation (Line(points={{-177,-26},{-251,-26}}, color={95,95,95}));
+    annotation (Line(points={{-186,-26},{-242,-26}}, color={95,95,95}));
   connect(P_w_HPSH1_out_sensor.C_out, HPsuperheater2.C_cold_in) annotation (
-     Line(points={{-214,8},{-263,8},{-263,-5}}, color={28,108,200}));
+     Line(points={{-214,8},{-260,8},{-260,-2}}, color={28,108,200}));
   connect(P_w_HPSH2_out_sensor.C_out, HPST_control_valve.C_in) annotation (Line(
         points={{-282,58},{-282,148},{-203.25,148}}, color={28,108,200}));
   connect(turbine_P_out_sensor.C_out, HPsuperheater2.C_hot_in)
-    annotation (Line(points={{-338,-26},{-293,-26}}, color={95,95,95}));
+    annotation (Line(points={{-338,-26},{-302,-26}}, color={95,95,95}));
   connect(deSH_opening_sensor.Opening, deSH_controlValve.Opening)
     annotation (Line(points={{-165,113.9},{-165,102.182}}, color={0,0,127}));
   connect(Q_deSH_sensor.C_in, loopBreaker.C_in) annotation (Line(points={{-132,92},
           {182,92},{182,38}}, color={28,108,200}));
-  connect(Q_deSH_sensor.C_out, deSH_controlValve.C_in) annotation (Line(points={{-144,92},
-          {-152,92},{-152,92},{-158.75,92}},           color={28,108,200}));
+  connect(Q_deSH_sensor.C_out, deSH_controlValve.C_in) annotation (Line(points={{-144,92},{-152,92},{-152,92},{-158.75,92}},
+                                                       color={28,108,200}));
   connect(deSH_controlValve.C_out, HPsuperheater2.C_cold_in) annotation (Line(
-        points={{-171.25,92},{-230,92},{-230,8},{-263,8},{-263,-5}}, color={28,108,
+        points={{-171.25,92},{-230,92},{-230,8},{-260,8},{-260,-2}}, color={28,108,
           200}));
   connect(T_w_HPSH2_out_sensor.C_in, HPsuperheater2.C_cold_out) annotation (
-      Line(points={{-282,28},{-282,12},{-282,-5},{-281,-5}}, color={28,108,200}));
+      Line(points={{-282,28},{-282,12},{-282,-2},{-284,-2}}, color={28,108,200}));
   connect(P_w_HPSH2_out_sensor.C_in, T_w_HPSH2_out_sensor.C_out)
     annotation (Line(points={{-282,46},{-282,40}}, color={28,108,200}));
   connect(P_w_eco_out_sensor.C_out, Evap_controlValve.C_in) annotation (Line(
@@ -767,15 +767,15 @@ equation
   connect(Evap_controlValve.Opening, Evap_opening_sensor.Opening)
     annotation (Line(points={{35,18.1822},{35,33.9}}, color={0,0,127}));
   connect(economiser.C_hot_out, T_flue_gas_sink_sensor.C_in) annotation (Line(
-        points={{123.3,-26.5},{123.3,-26},{164,-26}}, color={95,95,95}));
+        points={{132,-26.5},{132,-26},{164,-26}},     color={95,95,95}));
   connect(T_flue_gas_sink_sensor.C_out, P_flue_gas_sink_sensor.C_in)
     annotation (Line(points={{176,-26},{222,-26},{222,166}}, color={95,95,95}));
   connect(P_source_air_sensor.C_in, moistAir_to_FlueGases.outlet) annotation (Line(points={{-636,-26},{-652,-26}}, color={95,95,95}));
   connect(moistAir_to_FlueGases.inlet, source_air.C_out) annotation (Line(points={{-672,-26},{-693,-26}}, color={85,170,255}));
   connect(P_HPST_out_sensor.C_out, T_HPST_out_sensor.C_in) annotation (Line(points={{-102,148},{-96,148}}, color={28,108,200}));
-  connect(T_HPST_out_sensor.C_out, Reheater.C_cold_in) annotation (Line(points={{-84,148},{-63,148},{-63,-5}}, color={28,108,200}));
+  connect(T_HPST_out_sensor.C_out, Reheater.C_cold_in) annotation (Line(points={{-84,148},{-60,148},{-60,-2}}, color={28,108,200}));
   connect(airCompressor.C_W_in, gasTurbine.C_W_shaft) annotation (Line(
-      points={{-496,-12},{-496,8},{-382,8},{-382,-10}},
+      points={{-496,-15.5},{-496,8},{-382,8},{-382,-10}},
       color={244,125,35},
       smooth=Smooth.Bezier));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-720,-120},{260,280}})),
@@ -905,60 +905,6 @@ equation
           horizontalAlignment=TextAlignment.Left,
           fontSize=8,
           textString="Observables not used for calibration"),
-        Line(
-          points={{-687,164},{-653,164}},
-          color={95,95,95},
-          thickness=0.5),
-        Text(
-          extent={{-634,169},{-548,159}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=8,
-          textString="Flue Gas flow"),
-        Line(
-          points={{-687,132},{-653,132}},
-          color={238,46,47},
-          thickness=0.5),
-        Text(
-          extent={{-634,137},{-548,127}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=8,
-          textString="HP flow"),
-        Line(
-          points={{-687,118},{-653,118}},
-          color={244,125,35},
-          thickness=0.5),
-        Text(
-          extent={{-634,123},{-548,113}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=8,
-          textString="IP flow"),
-        Line(
-          points={{-687,104},{-653,104}},
-          color={244,237,30},
-          thickness=0.5),
-        Text(
-          extent={{-634,109},{-548,99}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=8,
-          textString="LP flow"),
-        Text(
-          extent={{-590,125},{-504,115}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=7,
-          textString="Solid Line: Liquid Phase
-Dashed Line: Vapor Phase"),
-        Text(
-          extent={{-614,149},{-528,139}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=8,
-          textString="Water/Steam"),
-        Rectangle(extent={{-696,152},{-490,94}}, lineColor={0,0,0}),
                                           Text(
           extent={{-306,-48},{-244,-54}},
           textColor={0,0,0},

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
@@ -33,6 +33,9 @@ model Evaporator
 
     // Indicators
     Units.Temperature T_approach(start=T_cold_out_0-T_cold_in_0);
+    Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
+    Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
+    Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
 
     // Failure modes
     parameter Boolean faulty = false;
@@ -147,6 +150,13 @@ equation
   HX_vaporising.T_hot_in = hot_side_vaporising.T_in;
   HX_vaporising.Cp_cold = 0; // Not used by NTU method in evaporator mode
   HX_vaporising.Cp_hot =MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium.specificHeatCapacityCp(hot_side_vaporising.state_in);
+
+  DT_hot_in_side = T_hot_in - T_cold_out;
+  DT_hot_out_side = T_hot_out - T_cold_in;
+  pinch = min(DT_hot_in_side, DT_hot_out_side);
+
+  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+
 
   connect(hot_side_pipe.C_out,hot_side_vaporising. C_in) annotation (Line(points={{-38,-20},{-30,-20}}, color={95,95,95}));
   connect(C_cold_in,cold_side_pipe. C_in) annotation (Line(points={{40,80},{40,58},{42,58},{42,44}},

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
@@ -31,6 +31,9 @@ model Evaporator
     Units.Temperature T_cold_out(start=T_cold_out_0);
     Units.Temperature T_hot_out(start=T_hot_out_0);
 
+    // Indicators
+    Units.Temperature T_approach(start=T_cold_out_0-T_cold_in_0);
+
     // Failure modes
     parameter Boolean faulty = false;
     Units.Percentage fouling; // Fouling percentage
@@ -105,6 +108,9 @@ equation
   Tsat = cold_side_heating.T_out;
   h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(cold_side_heating.P_in));
   h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(cold_side_heating.P_in));
+
+  // Indicators
+  T_approach = cold_side_heating.DT;
 
     // Pressure losses
   cold_side_pipe.delta_z=0;

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -20,47 +20,58 @@ model FuelHeater
   Units.Power W;
 
   // Definitions
-  Units.MassFlowRate Q_cold;
-  Units.MassFlowRate Q_hot;
-  Units.Temperature T_cold_in;
-  Units.Temperature T_cold_out;
-  Units.Temperature T_hot_in;
-  Units.Temperature T_hot_out;
+  Units.MassFlowRate Q_cold(start=Q_cold_0);
+  Units.MassFlowRate Q_hot(start=Q_hot_0);
+  Units.Temperature T_cold_in(start=T_cold_in_0);
+  Units.Temperature T_cold_out(start=T_cold_out_0);
+  Units.Temperature T_hot_in(start=T_hot_in_0);
+  Units.Temperature T_hot_out(start=T_hot_out_0);
+
+  // Indicators
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
 
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
 
   // Initialization parameters
-  parameter Units.MassFlowRate Q_cold_0 = 500;
-  parameter Units.MassFlowRate Q_hot_0 = 50;
-  parameter Units.Temperature T_hot_in_0 = 76 + 273.15;
-  parameter Units.Pressure P_hot_in_0 = 18 *1e5;
-  parameter Real h_hot_in_0 = 1e6;
+  // Flow Rates
+  parameter Units.MassFlowRate Q_cold_0 = 15;
+  parameter Units.MassFlowRate Q_hot_0 = 11;
+  // Temperatures
+  parameter Units.Temperature T_cold_in_0 = 8 + 273.15;
+  parameter Units.Temperature T_cold_out_0 = 200 + 273.15;
+  parameter Units.Temperature T_hot_in_0 = 210 + 273.15;
+  parameter Units.Temperature T_hot_out_0 = 68 + 273.15;
+  // Pressures
+  parameter Units.Pressure P_cold_in_0 = 30e5;
+  parameter Units.Pressure P_cold_out_0 = 29.5e5;
+  parameter Units.Pressure P_hot_in_0 = 18.5e5;
+  parameter Units.Pressure P_hot_out_0 = 18.3e5;
+  // Enthalpies
+  parameter Units.SpecificEnthalpy h_cold_in_0 = 554708.5;
+  parameter Units.SpecificEnthalpy h_cold_out_0 = 292266.22;
+  parameter Units.SpecificEnthalpy h_hot_in_0 = 958265.3;
+  parameter Units.SpecificEnthalpy h_hot_out_0 = 5.75e5;
 
-  Fuel.Connectors.Inlet C_cold_in annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));
-  Fuel.Connectors.Outlet C_cold_out annotation (Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(extent={{90,-10},{110,10}})));
-  WaterSteam.Connectors.Inlet C_hot_in annotation (Placement(transformation(extent={{30,70},{50,90}}), iconTransformation(extent={{30,70},{50,90}})));
-  WaterSteam.Connectors.Outlet C_hot_out(h_outflow(start=h_hot_in_0)) annotation (Placement(transformation(extent={{-50,-90},{-30,-70}}),
+  Fuel.Connectors.Inlet C_cold_in(Q(start=Q_cold_0), P(start=P_cold_in_0)) annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));
+  Fuel.Connectors.Outlet C_cold_out(Q(start=-Q_cold_0), P(start=P_cold_out_0), h_outflow(start= h_cold_out_0)) annotation (Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(extent={{90,-10},{110,10}})));
+  WaterSteam.Connectors.Inlet C_hot_in(Q(start=Q_hot_0), P(start=P_hot_in_0)) annotation (Placement(transformation(extent={{30,70},{50,90}}), iconTransformation(extent={{30,70},{50,90}})));
+  WaterSteam.Connectors.Outlet C_hot_out(Q(start=-Q_hot_0), P(start=P_hot_out_0), h_outflow(start = h_hot_out_0)) annotation (Placement(transformation(extent={{-50,-90},{-30,-70}}),
                                                                                                            iconTransformation(extent={{-50,-90},{-30,-70}})));
-  Power.HeatExchange.NTUHeatExchange HX(
-    config=HX_config,
-    QCp_max_side=QCp_max_side,
-    T_hot_in_0=T_hot_in_0)                                                                                                  annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX(config=HX_config, QCp_max_side=QCp_max_side,T_cold_in_0=T_cold_in_0, T_hot_in_0=T_hot_in_0) annotation (Placement(transformation(
         extent={{-10,10},{10,-10}},
         rotation=0,
         origin={10,14})));
-  WaterSteam.BaseClasses.IsoPFlowModel hot_side(
-    Q_0=Q_hot_0,
-    T_in_0=T_hot_in_0,
-    P_in_0=P_hot_in_0,
-    h_in_0=h_hot_in_0) annotation (Placement(transformation(
+  WaterSteam.BaseClasses.IsoPFlowModel hot_side(Q_0=Q_hot_0, h_in_0=h_hot_in_0, T_out_0=T_hot_out_0, P_0=P_hot_out_0, h_out_0=h_hot_out_0) annotation (Placement(transformation(
         extent={{10,10},{-10,-10}},
         rotation=0,
         origin={10,28})));
-  Fuel.Pipes.Pipe cold_side_pipe annotation (Placement(transformation(extent={{-52,-10},{-32,10}})));
-  Fuel.BaseClasses.IsoPFlowModel cold_side annotation (Placement(transformation(extent={{0,-10},{20,10}})));
-  WaterSteam.Pipes.Pipe hot_side_pipe(Q_0=Q_hot_0, T_in_0=T_hot_in_0, h_in_0=h_hot_in_0) annotation (Placement(transformation(
+  Fuel.Pipes.Pipe cold_side_pipe(Q_0=Q_cold_0, h_0=h_cold_in_0, T_0=T_cold_in_0, P_in_0=P_cold_in_0, P_out_0=P_cold_out_0) annotation (Placement(transformation(extent={{-52,-10},{-32,10}})));
+  Fuel.BaseClasses.IsoPFlowModel cold_side(Q_0=Q_cold_0, h_in_0=h_cold_in_0, T_in_0=T_cold_in_0, P_0=P_cold_in_0, T_out_0=T_cold_out_0, h_out_0=h_cold_out_0) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
+  WaterSteam.Pipes.Pipe hot_side_pipe(Q_0=Q_hot_0, h_0=h_hot_in_0, P_in_0=P_hot_in_0, P_out_0=P_hot_out_0) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={40,44})));
@@ -111,7 +122,12 @@ equation
   HX.Cp_cold = (Cp_cold_min + Cp_cold_max)/2;
   HX.Cp_hot = (Cp_hot_min + Cp_hot_max)/2;
 
+  // Indicators
+  DT_hot_in_side = T_hot_in - T_cold_out;
+  DT_hot_out_side = T_hot_out - T_cold_in;
+  pinch = min(DT_hot_in_side, DT_hot_out_side);
 
+  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
   Cp_cold_min = FuelMedium.specificHeatCapacityCp(cold_side.state_in); // fuel steam inlet Cp
   state_cold_out = FuelMedium.setState_pTX(cold_side.P_in, cold_side.T_in + nominal_cold_side_temperature_rise,cold_side.Xi);

--- a/MetroscopeModelingLibrary/Power/HeatExchange/NTUHeatExchange.mo
+++ b/MetroscopeModelingLibrary/Power/HeatExchange/NTUHeatExchange.mo
@@ -9,6 +9,7 @@ model NTUHeatExchange
   parameter Units.MassFlowRate Q_cold_0 = 1500 "Init parameter for Cold mass flow rate at the inlet";
   parameter Units.Temperature T_hot_in_0 = 273.15 + 200 "Init parameter for Hot mass flow rate at the inlet";
   parameter Units.Temperature T_cold_in_0 = 273.15 + 100 "Init parameter for Cold mass flow rate at the inlet";
+
   parameter Units.HeatCapacity Cp_hot_0 = 45 "Init parameter for Hot fluid specific heat capacity";
   parameter Units.HeatCapacity Cp_cold_0 = 75 "Init parameter for Cold fluid specific heat capacity";
   parameter Units.Area S_0 = 100 "init parameter for Heat exchange surface";
@@ -32,6 +33,7 @@ model NTUHeatExchange
   Inputs.InputTemperature T_hot_in(start=T_hot_in_0) "Temperature, hot side, at the inlet";
   Inputs.InputTemperature T_cold_in(start=T_cold_in_0) "Temperature, cold side, at the inlet";
 
+
   // Exchange parameters
   Real QCpMIN(unit="W/K", start=QCpMIN_0);
   Real QCpMAX(unit="W/K", start=QCpMAX_0);
@@ -39,6 +41,7 @@ model NTUHeatExchange
   Units.Fraction Cr(start=Cr_0);
   Units.Fraction epsilon(start=epsilon_0);
   Units.Power W_max(start=W_max_0);
+
 
   // When the QCp_max_side is "hot", the initial parameters may be in the opposite order, however, no impact on the simulations
   parameter Real QCpMIN_0(unit="W/K") = if QCp_max_side == "hot" then Q_cold_0 * Cp_cold_0 elseif QCp_max_side == "cold" then Q_hot_0 * Cp_hot_0 else min(Q_cold_0 * Cp_cold_0,Q_hot_0 * Cp_hot_0);
@@ -48,6 +51,8 @@ model NTUHeatExchange
   parameter Units.Fraction epsilon_0 = 0.9;
   parameter Units.Power W_max_0 = QCpMIN_0*(T_hot_in_0 - T_cold_in_0);
   parameter Units.Power W_0 = epsilon_0*W_max_0;
+
+
 equation
 
   W_max = QCpMIN*(T_hot_in - T_cold_in);
@@ -59,6 +64,7 @@ equation
 
     /* This is a monophasic shell and tube heat exchanger with two tube passes, 
     for instance for U-shaped tubes */
+
 
     if QCp_max_side == "hot" then
       QCpMAX = Q_hot*Cp_hot;

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_direct.mo
@@ -22,17 +22,17 @@ model FuelHeater_direct
   parameter Units.FrictionCoefficient Kfr_hot = 0;
   parameter Units.FrictionCoefficient Kfr_cold = 1;
 
-  MultiFluid.HeatExchangers.FuelHeater fuelHeater(QCp_max_side=QCp_max_side) annotation (Placement(transformation(extent={{-50,-48},{50,48}})));
-  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-78,-10},{-58,10}})));
-  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{60,-10},{80,10}})));
+  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-74,-10},{-54,10}})));
+  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{54,-10},{74,10}})));
   MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source   annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        rotation=-90,
-        origin={16,62})));
+        rotation=180,
+        origin={64,40})));
   MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={-20,-80})));
+        rotation=180,
+        origin={-64,-40})));
+  MultiFluid.HeatExchangers.FuelHeater fuelHeater annotation (Placement(transformation(extent={{-6,-10},{14,10}})));
 equation
 
   hot_source.P_out = P_hot_source * 1e5;
@@ -52,9 +52,9 @@ equation
   fuelHeater.Kfr_hot = Kfr_hot;
   fuelHeater.Kfr_cold = Kfr_cold;
 
-  connect(fuelHeater.C_cold_in, cold_source.C_out) annotation (Line(points={{-35,0},{-63,0}}, color={213,213,0}));
-  connect(fuelHeater.C_cold_out, cold_sink.C_in) annotation (Line(points={{35,0},{65,0}}, color={213,213,0}));
-  connect(fuelHeater.C_hot_out, hot_sink.C_in) annotation (Line(points={{-20,-33.6},{-20,-75}},          color={28,108,200}));
-  connect(fuelHeater.C_hot_in, hot_source.C_out) annotation (Line(points={{20,33.6},{16,33.6},{16,57}}, color={28,108,200}));
+  connect(fuelHeater.C_cold_in, cold_source.C_out) annotation (Line(points={{-6,0},{-59,0}}, color={213,213,0}));
+  connect(fuelHeater.C_cold_out, cold_sink.C_in) annotation (Line(points={{14,0},{59,0}}, color={213,213,0}));
+  connect(hot_source.C_out, fuelHeater.C_hot_in) annotation (Line(points={{59,40},{8,40},{8,8}}, color={28,108,200}));
+  connect(fuelHeater.C_hot_out, hot_sink.C_in) annotation (Line(points={{0,-8},{0,-40},{-59,-40}}, color={28,108,200}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
 end FuelHeater_direct;

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_reverse.mo
@@ -27,26 +27,27 @@ model FuelHeater_reverse
   input Real T_hot_out(start = 80, min = 0, nominal = 100) "degC"; // Outlet temperature on cold side, to calibrate Kth
   //input Real T_cold_out(start = 200, nominal = 200)"degC";
 
-  MultiFluid.HeatExchangers.FuelHeater fuelHeater(QCp_max_side = QCp_max_side) annotation (Placement(transformation(extent={{-38,-34},{38,34}})));
   MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={14,50})));
+        rotation=180,
+        origin={64,40})));
   MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={-16,-88})));
-  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-66,-10},{-46,10}})));
-  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{74,-10},{94,10}})));
-  MetroscopeModelingLibrary.Sensors.Fuel.PressureSensor P_cold_out_sensor annotation (Placement(transformation(extent={{46,-10},{66,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_hot_out_sensor annotation (Placement(transformation(
+        origin={-20,-90})));
+  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-74,-10},{-54,10}})));
+  MetroscopeModelingLibrary.Fuel.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{54,-10},{74,10}})));
+  MetroscopeModelingLibrary.Sensors.Fuel.PressureSensor P_cold_out_sensor annotation (Placement(transformation(extent={{20,-10},{40,10}})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_hot_out_sensor(h_0=5.75e5)
+                                                                                  annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={-16,-40})));
+        origin={-20,-40})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_hot_out_sensor annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={-16,-66})));
+        origin={-20,-68})));
+  MultiFluid.HeatExchangers.FuelHeater fuelHeater annotation (Placement(transformation(extent={{-14,-10},{6,10}})));
 equation
   // Boundary conditions
   hot_source.P_out = P_hot_source * 1e5;
@@ -74,15 +75,14 @@ equation
   fuelHeater.Kfr_hot = Kfr_hot;
   fuelHeater.Kfr_cold = Kfr_cold;
 
-  connect(fuelHeater.C_hot_in, hot_source.C_out) annotation (Line(points={{15.2,23.8},{14,23.8},{14,45}}, color={28,108,200}));
-  connect(fuelHeater.C_cold_in, cold_source.C_out) annotation (Line(points={{-26.6,0},{-51,0}}, color={213,213,0}));
-  connect(fuelHeater.C_cold_out, P_cold_out_sensor.C_in) annotation (Line(points={{26.6,0},{46,0}}, color={213,213,0}));
-  connect(cold_sink.C_in, P_cold_out_sensor.C_out) annotation (Line(points={{79,0},{66,0}}, color={213,213,0}));
-  connect(fuelHeater.C_hot_out, T_hot_out_sensor.C_in) annotation (Line(points={{-15.2,-23.8},{-15.2,-26.9},{-16,-26.9},{-16,-30}},
-                                                                                                                                color={28,108,200}));
-  connect(T_hot_out_sensor.C_out, P_hot_out_sensor.C_in) annotation (Line(points={{-16,-50},{-16,-53},{-16,-53},{-16,-56}},
+  connect(cold_sink.C_in, P_cold_out_sensor.C_out) annotation (Line(points={{59,0},{40,0}}, color={213,213,0}));
+  connect(T_hot_out_sensor.C_out, P_hot_out_sensor.C_in) annotation (Line(points={{-20,-50},{-20,-58}},
                                                                                                       color={28,108,200}));
-  connect(hot_sink.C_in, P_hot_out_sensor.C_out) annotation (Line(points={{-16,-83},{-16,-76}},
+  connect(hot_sink.C_in, P_hot_out_sensor.C_out) annotation (Line(points={{-20,-85},{-20,-78}},
                                                                                               color={28,108,200}));
+  connect(fuelHeater.C_cold_out, P_cold_out_sensor.C_in) annotation (Line(points={{6,0},{20,0}}, color={213,213,0}));
+  connect(fuelHeater.C_hot_out, T_hot_out_sensor.C_in) annotation (Line(points={{-8,-8},{-8,-20},{-20,-20},{-20,-30}}, color={28,108,200}));
+  connect(hot_source.C_out, fuelHeater.C_hot_in) annotation (Line(points={{59,40},{0,40},{0,8}}, color={28,108,200}));
+  connect(fuelHeater.C_cold_in, cold_source.C_out) annotation (Line(points={{-14,0},{-59,0}}, color={213,213,0}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)));
 end FuelHeater_reverse;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_reverse.mo
@@ -37,9 +37,10 @@ model Reheater_reverse
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-56})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_cold_sink_sensor annotation (Placement(transformation(extent={{48,-10},{68,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cold_sink_sensor annotation (Placement(transformation(extent={{22,-10},{42,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_drains_sensor annotation (Placement(transformation(
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_cold_sink_sensor annotation (Placement(transformation(extent={{24,-10},{44,10}})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cold_sink_sensor annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_drains_sensor(P_0=1100000)
+                                                                                 annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-30})));
@@ -72,13 +73,12 @@ equation
           25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
   connect(cold_source.C_out, reheater.C_cold_in)
     annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
-  connect(reheater.C_cold_out, P_cold_sink_sensor.C_in)
-    annotation (Line(points={{16,0},{22,0}}, color={28,108,200}));
-  connect(P_cold_sink_sensor.C_out, T_cold_sink_sensor.C_in) annotation (Line(points={{42,0},{48,0}}, color={28,108,200}));
-  connect(T_cold_sink_sensor.C_out, cold_sink.C_in) annotation (Line(points={{68,0},{73,0}}, color={28,108,200}));
   connect(T_drains_sensor.C_in, reheater.C_hot_out) annotation (Line(points={{1.77636e-15,
           -20},{1.77636e-15,-14},{0,-14},{0,-8}}, color={28,108,200}));
   connect(T_drains_sensor.C_out, hot_sink.C_in) annotation (Line(points={{-1.77636e-15,
           -40},{-1.77636e-15,-45.5},{8.88178e-16,-45.5},{8.88178e-16,-51}},
         color={28,108,200}));
+  connect(reheater.C_cold_out, T_cold_sink_sensor.C_in) annotation (Line(points={{16,0},{24,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.C_in, T_cold_sink_sensor.C_out) annotation (Line(points={{48,0},{44,0}}, color={28,108,200}));
+  connect(cold_sink.C_in, P_cold_sink_sensor.C_out) annotation (Line(points={{73,0},{68,0}}, color={28,108,200}));
 end Reheater_reverse;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_reverse.mo
@@ -35,7 +35,8 @@ model Superheater_reverse
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={0,24})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor drains_pressure_sensor annotation (Placement(transformation(extent={{38,-10},{58,10}})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor drains_pressure_sensor(Q_0=50)
+                                                                                     annotation (Placement(transformation(extent={{38,-10},{58,10}})));
 equation
 
   // Boundary conditions

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
@@ -128,7 +128,6 @@ equation
   // Pressure losses
   cold_side_pipe.delta_z=0;
   cold_side_pipe.Kfr = Kfr_cold;
-
   water_height_pipe.delta_z = - water_height;
   water_height_pipe.Kfr = 0;
   water_height_pipe.DP = water_height_DP;
@@ -147,6 +146,7 @@ equation
 
   // Heat Exchange
   0 = Tsat - T_cold_out - (Tsat - T_cold_in)*exp(Kth*(1-fouling/100)*S*((T_cold_in - T_cold_out)/W));
+
 
 
   connect(cold_side_pipe.C_out, cold_side.C_in) annotation (Line(

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
@@ -28,6 +28,11 @@ model DryReheater
   Units.Temperature T_hot_in(start=T_hot_in_0);
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
+  // Indicators
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
@@ -173,6 +178,13 @@ equation
   HX_condensing.T_hot_in = Tsat;
   HX_condensing.Cp_cold = WaterSteamMedium.specificHeatCapacityCp(cold_side_condensing.state_in);
   HX_condensing.Cp_hot = 0; // Not used by NTU method in condenser mode
+
+  // Indicators
+  DT_hot_in_side = T_hot_in - T_cold_out;
+  DT_hot_out_side = T_hot_out - T_cold_in;
+  pinch = min(DT_hot_in_side, DT_hot_out_side);
+
+  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
   // Internal leaks
   partition_plate.Q = 1e-5 + partition_plate_leak;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -20,6 +20,11 @@ model LiqLiqHX
   Units.Temperature T_hot_in(start=T_hot_in_0);
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
+  // Indicators
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
@@ -97,6 +102,13 @@ equation
   HX.T_hot_in = T_hot_in;
   HX.Cp_cold = WaterSteamMedium.specificHeatCapacityCp(cold_side.state_in);
   HX.Cp_hot = WaterSteamMedium.specificHeatCapacityCp(hot_side.state_in);
+
+  // Indicators
+  DT_hot_in_side = T_hot_in - T_cold_out;
+  DT_hot_out_side = T_hot_out - T_cold_in;
+  pinch = min(DT_hot_in_side, DT_hot_out_side);
+
+  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
 
   connect(cold_side_pipe.C_out, cold_side.C_in) annotation (Line(

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -42,6 +42,11 @@ model Reheater
   Units.Temperature T_hot_in(start=T_hot_in_0);
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
+  // Indicators
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
@@ -171,7 +176,7 @@ equation
   Q_cold_out = C_cold_out.Q;
   Q_hot_out = C_hot_out.Q;
   T_cold_in = cold_side_pipe.T_in;
-  T_cold_out =final_mix_cold.T_out;
+  T_cold_out = final_mix_cold.T_out;
                                 // A IsoPHFlowModel is necessary to have a full thermodynamic state with temperature calculation at the cold outlet
   T_hot_in = hot_side_pipe.T_in;
   T_hot_out = final_mix_hot.T_out;
@@ -236,6 +241,13 @@ equation
   HX_subcooling.T_hot_in = hot_side_subcooling.T_in;
   HX_subcooling.Cp_cold = WaterSteamMedium.specificHeatCapacityCp(cold_side_subcooling.state_in);
   HX_subcooling.Cp_hot = WaterSteamMedium.specificHeatCapacityCp(hot_side_subcooling.state_in);
+
+  // Indicators
+  DT_hot_in_side = T_hot_in - T_cold_out;
+  DT_hot_out_side = T_hot_out - T_cold_in;
+  pinch = min(DT_hot_in_side, DT_hot_out_side);
+
+  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
 
   // Internal leaks

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
@@ -47,6 +47,11 @@ model Superheater
   Units.Temperature T_hot_out(start=T_hot_out_0);
   Units.Power W;
 
+  // Indicators
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
@@ -244,6 +249,13 @@ equation
   else
       cold_side_vaporising.h_out = cold_side_vaporising.h_in;
   end if;
+
+  // Indicators
+  DT_hot_in_side = T_hot_in - T_cold_out;
+  DT_hot_out_side = T_hot_out - T_cold_in;
+  pinch = min(DT_hot_in_side, DT_hot_out_side);
+
+  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
   // Internal leaks
   tube_rupture.Q = 1e-5 + tube_rupture_leak;


### PR DESCRIPTION
## Goal

New indicators are added in all of the HX models, except the condenser and the ACC:
- `T_approach` only in the `Evaporator` model, and represents the difference between the water inlet temperature at the saturation temperature
- `DT_hot_in_side`: the difference between the hot inlet temperature and the corresponding cold temperature from the same side
- `DT_hot_out_side`: the difference between the hot outlet temperature and the corresponding cold temperature from the same side
- `pinch`: the minimum value between the two previous ones (the lowest temperature difference in the HX)

Other minor changes:
- Added initialization values in the `FuelHeater` model
- Improved the `FuelHeater` test diagrams

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [x] Bugfix
- [x] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [x] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
