### PR TITLE
Added standard performance indicators for HX

### DIFF
--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Economiser.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Economiser.mo
@@ -1,9 +1,18 @@
 within MetroscopeModelingLibrary.MultiFluid.HeatExchangers;
 model Economiser
+  import MetroscopeModelingLibrary.Utilities.Units;
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
   extends Partial.HeatExchangers.WaterFlueGasesMonophasicHX(
                                                     QCp_max_side = "hot")
  annotation(IconMap(primitivesVisible=false));
+
+ // Indicators
+ Units.DifferentialTemperature FTR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+
+equation
+
+  // Indicators
+  FTR = T_cold_out - T_cold_in;
 
   annotation (Icon(graphics={
           Rectangle(

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
@@ -32,7 +32,7 @@ model Evaporator
     Units.Temperature T_hot_out(start=T_hot_out_0);
 
     // Indicators
-    Units.Temperature T_approach(start=T_cold_out_0-T_cold_in_0) "Colde temperature inlet difference to saturation";
+    Units.Temperature T_approach(start=T_cold_out_0-T_cold_in_0) "Cold temperature inlet difference to saturation";
     Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0) "Temperature difference between hot and cold fluids, hot inlet side";
     Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0) "Temperature difference between hot and cold fluids, hot outlet side";
     Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
@@ -32,10 +32,10 @@ model Evaporator
     Units.Temperature T_hot_out(start=T_hot_out_0);
 
     // Indicators
-    Units.Temperature T_approach(start=T_cold_out_0-T_cold_in_0);
-    Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-    Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-    Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+    Units.Temperature T_approach(start=T_cold_out_0-T_cold_in_0) "Colde temperature inlet difference to saturation";
+    Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0) "Temperature difference between hot and cold fluids, hot inlet side";
+    Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0) "Temperature difference between hot and cold fluids, hot outlet side";
+    Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
     // Failure modes
     parameter Boolean faulty = false;
@@ -154,7 +154,6 @@ equation
   DT_hot_in_side = T_hot_in - T_cold_out;
   DT_hot_out_side = T_hot_out - T_cold_in;
   pinch = min(DT_hot_in_side, DT_hot_out_side);
-
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
 

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Evaporator.mo
@@ -154,7 +154,8 @@ equation
   DT_hot_in_side = T_hot_in - T_cold_out;
   DT_hot_out_side = T_hot_out - T_cold_in;
   pinch = min(DT_hot_in_side, DT_hot_out_side);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
 
   connect(hot_side_pipe.C_out,hot_side_vaporising. C_in) annotation (Line(points={{-38,-20},{-30,-20}}, color={95,95,95}));

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -126,7 +126,8 @@ equation
   DT_hot_in_side = T_hot_in - T_cold_out;
   DT_hot_out_side = T_hot_out - T_cold_in;
   pinch = min(DT_hot_in_side, DT_hot_out_side);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
   Cp_cold_min = FuelMedium.specificHeatCapacityCp(cold_side.state_in); // fuel steam inlet Cp
   state_cold_out = FuelMedium.setState_pTX(cold_side.P_in, cold_side.T_in + nominal_cold_side_temperature_rise,cold_side.Xi);

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -28,9 +28,9 @@ model FuelHeater
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
   // Indicators
-  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0) "Temperature difference between hot and cold fluids, hot inlet side";
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0) "Temperature difference between hot and cold fluids, hot outlet side";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
   // Failure modes
   parameter Boolean faulty = false;
@@ -126,7 +126,6 @@ equation
   DT_hot_in_side = T_hot_in - T_cold_out;
   DT_hot_out_side = T_hot_out - T_cold_in;
   pinch = min(DT_hot_in_side, DT_hot_out_side);
-
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
   Cp_cold_min = FuelMedium.specificHeatCapacityCp(cold_side.state_in); // fuel steam inlet Cp

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Superheater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Superheater.mo
@@ -1,5 +1,7 @@
 within MetroscopeModelingLibrary.MultiFluid.HeatExchangers;
 model Superheater
+  import MetroscopeModelingLibrary.Utilities.Units;
+  package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
   extends Partial.HeatExchangers.WaterFlueGasesMonophasicHX(
                                                     QCp_max_side = "hot",
@@ -16,7 +18,19 @@ model Superheater
                                                     h_hot_in_0 = 9.6e5,
                                                     h_hot_out_0 = 9.1e5)
  annotation(IconMap(primitivesVisible=false));
-  import MetroscopeModelingLibrary.Utilities.Units.Inputs;
+
+ // Indicators
+ Units.DifferentialTemperature STR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+ Units.DifferentialTemperature DT_superheat(start=T_cold_out_0-WaterSteamMedium.saturationTemperature(P_cold_in_0)) "Superheat temperature difference";
+
+equation
+
+  // Indicators
+  STR = T_cold_out - T_cold_in;
+  DT_superheat = T_cold_out - WaterSteamMedium.saturationTemperature(cold_side_pipe.P_in);
+
+
+
 
   annotation (Icon(graphics={
           Rectangle(

--- a/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
+++ b/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
@@ -130,7 +130,8 @@ equation
   DT_hot_in_side = T_hot_in - T_cold_out;
   DT_hot_out_side = T_hot_out - T_cold_in;
   pinch = min(DT_hot_in_side, DT_hot_out_side);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
   // For each medium, an average Cp is calculated beteween Cp inlet and an estimation of Cp outlet.
   // The estimation of the Cp outlet is calculated for an outlet temperature based on the nominal temperature rise of the H&MB diagram.

--- a/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
+++ b/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
@@ -27,9 +27,9 @@ partial model WaterFlueGasesMonophasicHX
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
   // Indicators
-  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0) "Temperature difference between hot and cold fluids, hot inlet side";
+  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0) "Temperature difference between hot and cold fluids, hot outlet side";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
   // Failure modes
   parameter Boolean faulty = false;
@@ -124,20 +124,13 @@ equation
   HX.Q_hot = Q_hot;
   HX.T_cold_in = T_cold_in;
   HX.T_hot_in = T_hot_in;
-//   HX.T_cold_out = T_cold_out;
-//   HX.T_hot_out = T_hot_out;
   HX.Cp_cold = (Cp_cold_min + Cp_cold_max)/2;
   HX.Cp_hot = (Cp_hot_min + Cp_hot_max)/2;
 
   DT_hot_in_side = T_hot_in - T_cold_out;
   DT_hot_out_side = T_hot_out - T_cold_in;
   pinch = min(DT_hot_in_side, DT_hot_out_side);
-
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
-
-//   HX.DT_hot_in_side = DT_hot_in_side;
-//   HX.DT_hot_out_side = DT_hot_out_side;
-//   HX.pinch = pinch;
 
   // For each medium, an average Cp is calculated beteween Cp inlet and an estimation of Cp outlet.
   // The estimation of the Cp outlet is calculated for an outlet temperature based on the nominal temperature rise of the H&MB diagram.

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
@@ -185,7 +185,8 @@ equation
   TTD = T_hot_in - T_cold_out;
   DCA = T_hot_out - T_cold_in;
   pinch = min(TTD, DCA);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
   // Internal leaks
   partition_plate.Q = 1e-5 + partition_plate_leak;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
@@ -29,9 +29,10 @@ model DryReheater
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
   // Indicators
-  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+  Units.DifferentialTemperature FTR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+  Units.DifferentialTemperature TTD(start=T_hot_in_0-T_cold_out_0) "Terminal Temperature Difference";
+  Units.DifferentialTemperature DCA(start=T_hot_out_0-T_cold_in_0) "Drain Cooler Approach";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
   // Failure modes
   parameter Boolean faulty = false;
@@ -180,10 +181,10 @@ equation
   HX_condensing.Cp_hot = 0; // Not used by NTU method in condenser mode
 
   // Indicators
-  DT_hot_in_side = T_hot_in - T_cold_out;
-  DT_hot_out_side = T_hot_out - T_cold_in;
-  pinch = min(DT_hot_in_side, DT_hot_out_side);
-
+  FTR = T_cold_out - T_cold_in;
+  TTD = T_hot_in - T_cold_out;
+  DCA = T_hot_out - T_cold_in;
+  pinch = min(TTD, DCA);
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
   // Internal leaks

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -21,9 +21,10 @@ model LiqLiqHX
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
   // Indicators
-  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+  Units.DifferentialTemperature FTR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+  Units.DifferentialTemperature TTD(start=T_hot_in_0-T_cold_out_0) "Terminal Temperature Difference";
+  Units.DifferentialTemperature DCA(start=T_hot_out_0-T_cold_in_0) "Drain Cooler Approach";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
   // Failure modes
   parameter Boolean faulty = false;
@@ -104,10 +105,10 @@ equation
   HX.Cp_hot = WaterSteamMedium.specificHeatCapacityCp(hot_side.state_in);
 
   // Indicators
-  DT_hot_in_side = T_hot_in - T_cold_out;
-  DT_hot_out_side = T_hot_out - T_cold_in;
-  pinch = min(DT_hot_in_side, DT_hot_out_side);
-
+  FTR = T_cold_out - T_cold_in;
+  TTD = T_hot_in - T_cold_out;
+  DCA = T_hot_out - T_cold_in;
+  pinch = min(TTD, DCA);
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
 

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -109,7 +109,8 @@ equation
   TTD = T_hot_in - T_cold_out;
   DCA = T_hot_out - T_cold_in;
   pinch = min(TTD, DCA);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
 
   connect(cold_side_pipe.C_out, cold_side.C_in) annotation (Line(

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -248,7 +248,8 @@ equation
   TTD = T_hot_in - T_cold_out;
   DCA = T_hot_out - T_cold_in;
   pinch = min(TTD, DCA);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
 
   // Internal leaks

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -43,9 +43,10 @@ model Reheater
   Units.Temperature T_hot_out(start=T_hot_out_0);
 
   // Indicators
-  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+  Units.DifferentialTemperature FTR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+  Units.DifferentialTemperature TTD(start=T_hot_in_0-T_cold_out_0) "Terminal Temperature Difference";
+  Units.DifferentialTemperature DCA(start=T_hot_out_0-T_cold_in_0) "Drain Cooler Approach";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
   // Failure modes
   parameter Boolean faulty = false;
@@ -243,10 +244,10 @@ equation
   HX_subcooling.Cp_hot = WaterSteamMedium.specificHeatCapacityCp(hot_side_subcooling.state_in);
 
   // Indicators
-  DT_hot_in_side = T_hot_in - T_cold_out;
-  DT_hot_out_side = T_hot_out - T_cold_in;
-  pinch = min(DT_hot_in_side, DT_hot_out_side);
-
+  FTR = T_cold_out - T_cold_in;
+  TTD = T_hot_in - T_cold_out;
+  DCA = T_hot_out - T_cold_in;
+  pinch = min(TTD, DCA);
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
 

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
@@ -24,7 +24,7 @@ model Superheater
   // Vaporising
   Units.Power W_vap;
   Units.SpecificEnthalpy h_vap_sat_cold(start=h_cold_in_0);
-  Units.Temperature Tsat_cold;
+  Units.Temperature Tsat_cold(start=T_cold_in_0);
 
   // Ventilation
   Units.PositiveMassFlowRate Q_vent(start=Q_vent_0);
@@ -48,9 +48,10 @@ model Superheater
   Units.Power W;
 
   // Indicators
-  Units.DifferentialTemperature DT_hot_in_side(start=T_hot_in_0-T_cold_out_0);
-  Units.DifferentialTemperature DT_hot_out_side(start=T_hot_out_0-T_cold_in_0);
-  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0));
+  Units.DifferentialTemperature DT_superheat(start=T_cold_out_0-T_cold_in_0) "Superheat temperature difference";
+  Units.DifferentialTemperature TTD(start=T_hot_in_0-T_cold_out_0) "Terminal Temperature Difference";
+  Units.DifferentialTemperature DCA(start=T_hot_out_0-T_cold_in_0) "Drain Cooler Approach";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
 
   // Failure modes
   parameter Boolean faulty = false;
@@ -251,10 +252,10 @@ equation
   end if;
 
   // Indicators
-  DT_hot_in_side = T_hot_in - T_cold_out;
-  DT_hot_out_side = T_hot_out - T_cold_in;
-  pinch = min(DT_hot_in_side, DT_hot_out_side);
-
+  DT_superheat = T_cold_out - Tsat_cold;
+  TTD = T_hot_in - T_cold_out;
+  DCA = T_hot_out - T_cold_in;
+  pinch = min(TTD, DCA);
   assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
 
   // Internal leaks

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
@@ -256,7 +256,8 @@ equation
   TTD = T_hot_in - T_cold_out;
   DCA = T_hot_out - T_cold_in;
   pinch = min(TTD, DCA);
-  assert(pinch > 0, "A very low or negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
   // Internal leaks
   tube_rupture.Q = 1e-5 + tube_rupture_leak;


### PR DESCRIPTION
## Goal

Added standard performance indicators to heat exchangers.

Feedwater heaters:
- `FTR` Feedwater Temperature Rise. Difference between the feedwater inlet and outlet temperatures
- `TTD` Terminal Temperature Difference. Difference between hot side saturation temperature and feedwater outlet temperature
- `DCA` Drain Cooler Approach. Difference between hot side drain temperature and feedwater inlet temperature

Economizer:
Only `FTR` since the hot fluid is flue gases

Superheaters:
- `DT_superheat`: Outlet temperature difference to saturation (degrees of superheat)
- `STR` Steam Temperature Rise (only for the multifluid superheater): Steam temperature difference across the HX
- `TTD` and `DCA`: Only for water/water superheater

(No modifications are needed in the Changelog)

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
