### PR TITLE
Warning if steam is superheated at the condenser inlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 
 -  ✨ Add and correct initialization parameters in flue gases [#436](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/436/files)
 -  ✨ Add indicators in the HX models
+-  ✨ Added a wawrning if the steam admitted in the condenser is superheated
 
 ### :bug: Fixed <!--Make sure to add a link to the PR and issues related to your change-->
 - :wrench: Initialisation parameters and unit tests of the multifluid heat exchangers fix for a better convergence

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Superheater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/Superheater.mo
@@ -20,7 +20,7 @@ model Superheater
  annotation(IconMap(primitivesVisible=false));
 
  // Indicators
- Units.DifferentialTemperature STR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+ Units.DifferentialTemperature STR(start=T_cold_out_0-T_cold_in_0) "Steam Temperature Rise";
  Units.DifferentialTemperature DT_superheat(start=T_cold_out_0-WaterSteamMedium.saturationTemperature(P_cold_in_0)) "Superheat temperature difference";
 
 equation

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_direct.mo
@@ -19,17 +19,17 @@ model Condenser_direct
   parameter Utilities.Units.Pressure P_offset=0;
   parameter Real C_incond = 0;
 
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cooling_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cooling_source annotation (Placement(transformation(extent={{-56,-10},{-36,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{36,-10},{56,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source turbine_outlet annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,30})));
+        origin={0,46})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink condensate_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-30})));
+        origin={0,-46})));
+  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser annotation (Placement(transformation(extent={{-10,-8},{10,10}})));
 equation
 
   turbine_outlet.h_out = h_turbine;
@@ -46,14 +46,10 @@ equation
   condenser.P_offset = P_offset;
   condenser.C_incond = C_incond;
 
-  connect(condenser.C_cold_out, cooling_sink.C_in) annotation (Line(points={{16,
-          -1.42222},{30,-1.42222},{30,0},{45,0}}, color={28,108,200}));
-  connect(condensate_sink.C_in, condenser.C_hot_out) annotation (Line(points={{8.88178e-16,
-          -25},{8.88178e-16,-20.5},{0,-20.5},{0,-8.35556}}, color={28,108,200}));
-  connect(turbine_outlet.C_out, condenser.C_hot_in) annotation (Line(points={{-8.88178e-16,
-          25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
-  connect(cooling_source.C_out, condenser.C_cold_in) annotation (Line(points={{-43,
-          0},{-30,0},{-30,3.55556},{-16.64,3.55556}}, color={28,108,200}));
+  connect(turbine_outlet.C_out, condenser.C_hot_in) annotation (Line(points={{-8.88178e-16,41},{-8.88178e-16,25.6},{0,25.6},{0,10.2}}, color={28,108,200}));
+  connect(cooling_source.C_out, condenser.C_cold_in) annotation (Line(points={{-41,0},{-10,0}}, color={28,108,200}));
+  connect(cooling_sink.C_in, condenser.C_cold_out) annotation (Line(points={{41,0},{9.8,0}}, color={28,108,200}));
+  connect(condensate_sink.C_in, condenser.C_hot_out) annotation (Line(points={{8.88178e-16,-41},{8.88178e-16,-24.5},{0,-24.5},{0,-8}}, color={28,108,200}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,80}})),
                         Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_reverse.mo
@@ -23,30 +23,33 @@ model Condenser_reverse
     // Inputs for calibration
   input Real P_cond(start = 0.19e5) "Pa";
 
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source turbine_outlet annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,46})));
+        origin={0,78})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink condensate_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-44})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cond_sensor annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
-        rotation=270,
-        origin={1,25})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor circulating_water_T_out_sensor annotation (Placement(transformation(extent={{24,-6},{34,4}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor condensate_temperature_sensor annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
-        rotation=270,
-        origin={-1,-21})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor circulating_water_P_out_sensor annotation (Placement(transformation(extent={{40,-6},{50,4}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cooling_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
-        origin={-56,4})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{60,-10},{80,10}})));
+        origin={-44,0})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{74,-10},{94,10}})));
+  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser annotation (Placement(transformation(extent={{-10,-8},{10,10}})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor condensate_temperature_sensor annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,-24})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor circulating_water_T_out_sensor annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={30,0})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor circulating_water_P_out_sensor annotation (Placement(transformation(extent={{50,-10},{70,10}})));
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cond_sensor annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,40})));
 equation
 
   // Boundary Conditions
@@ -70,21 +73,14 @@ equation
   // Inputs for calibration
   P_cond_sensor.P = P_cond;
 
-  connect(condenser.C_hot_in, P_cond_sensor.C_out)
-    annotation (Line(points={{0,8},{0,20},{1,20}}, color={28,108,200}));
-  connect(turbine_outlet.C_out, P_cond_sensor.C_in) annotation (Line(points={{-8.88178e-16,
-          41},{0,41},{0,30},{1,30}}, color={28,108,200}));
-  connect(condenser.C_cold_out, circulating_water_T_out_sensor.C_in)
-    annotation (Line(points={{16,-0.888889},{16,-1},{24,-1}},color={28,108,200}));
-  connect(condensate_temperature_sensor.C_in, condenser.C_hot_out) annotation (
-      Line(points={{-1,-16},{0,-16},{0,-8}},       color={28,108,200}));
-  connect(condensate_temperature_sensor.C_out, condensate_sink.C_in)
-    annotation (Line(points={{-1,-26},{-1,-32.5},{8.88178e-16,-32.5},{8.88178e-16,
-          -39}}, color={28,108,200}));
-  connect(circulating_water_P_out_sensor.C_in, circulating_water_T_out_sensor.C_out)
-    annotation (Line(points={{40,-1},{34,-1}}, color={28,108,200}));
-  connect(condenser.C_cold_in, cooling_source.C_out) annotation (Line(points={{-16,2.66667},{-34,2.66667},{-34,4},{-51,4}},    color={28,108,200}));
-  connect(circulating_water_P_out_sensor.C_out, cooling_sink.C_in) annotation (Line(points={{50,-1},{57.5,-1},{57.5,0},{65,0}}, color={28,108,200}));
+  connect(condenser.C_cold_in, cooling_source.C_out) annotation (Line(points={{-10,0},{-39,0}}, color={28,108,200}));
+  connect(condenser.C_hot_out, condensate_temperature_sensor.C_in) annotation (Line(points={{0,-8},{0,-11},{1.77636e-15,-11},{1.77636e-15,-14}}, color={28,108,200}));
+  connect(condensate_sink.C_in, condensate_temperature_sensor.C_out) annotation (Line(points={{8.88178e-16,-39},{8.88178e-16,-36.5},{-1.77636e-15,-36.5},{-1.77636e-15,-34}}, color={28,108,200}));
+  connect(condenser.C_cold_out, circulating_water_T_out_sensor.C_in) annotation (Line(points={{9.8,0},{20,0}}, color={28,108,200}));
+  connect(circulating_water_T_out_sensor.C_out, circulating_water_P_out_sensor.C_in) annotation (Line(points={{40,0},{50,0}}, color={28,108,200}));
+  connect(circulating_water_P_out_sensor.C_out, cooling_sink.C_in) annotation (Line(points={{70,0},{79,0}}, color={28,108,200}));
+  connect(turbine_outlet.C_out, P_cond_sensor.C_in) annotation (Line(points={{-8.88178e-16,73},{-8.88178e-16,61.5},{1.77636e-15,61.5},{1.77636e-15,50}}, color={28,108,200}));
+  connect(condenser.C_hot_in, P_cond_sensor.C_out) annotation (Line(points={{0,10.2},{0,20.1},{-1.77636e-15,20.1},{-1.77636e-15,30}}, color={28,108,200}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,80}})),
                         Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
@@ -139,10 +139,14 @@ equation
   incondensables_in.DP = - P_incond;
   incondensables_out.DP = + P_incond;
 
+  // Saturated vapor admission check
+  assert(T_hot_in - Tsat < 0.1, "The steam admitted in the condenser in superheated", AssertionLevel.warning);
+
+
   // Condensation
   Psat = hot_side.P_in;
-  Tsat = hot_side.T_in;
-  hot_side.h_out = Water.bubbleEnthalpy(Water.setSat_T(Tsat));
+  Tsat =  Water.saturationTemperature(Psat);
+  hot_side.h_out = Water.bubbleEnthalpy(Water.setSat_p(Psat));
 
   // Heat Exchange
   0 = Tsat - T_cold_out - (Tsat - T_cold_in)*exp(Kth*(1-fouling/100)*S*((T_cold_in - T_cold_out)/W));


### PR DESCRIPTION
## Goal

Added a warning in the condenser if the admitted steam is not saturated.
Changed the outlet enthalpy to be calculated by Psat instead of Tsat (since the measured value is usually P)

Fixes #444 


## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
