### PR TITLE
Pressure loss simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 - 🔧 Added `rho_0` as an initialization parameter in the `FlowModel` [PR#440](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/440)
 
 ### 💥 Changed <!--Make sure to add a link to the PR and issues related to your change-->
+- Pressure losses equations in Pipe, ControlValve and SlidingValve now use inlet density instead of mean density. This change can affect calibrated models. [PR#450](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/450)
 
 ### 🔥 Removed <!--Make sure to add a link to the PR and issues related to your change-->
 

--- a/MetroscopeModelingLibrary/Examples/Nuclear/MetroscopiaNPP/MetroscopiaNPP_direct.mo
+++ b/MetroscopeModelingLibrary/Examples/Nuclear/MetroscopiaNPP/MetroscopiaNPP_direct.mo
@@ -583,8 +583,7 @@ equation
     HP_heater.Kfr_cold = HP_heater_Kfr_cold;
   HP_reheater_drains_control_valve.Cv_max = HP_heater_drains_control_valve_Cvmax;
 
-  connect(HP_control_valve.C_out, HPT_P_in_sensor.C_in) annotation (Line(points={{-125,72},
-          {-116,72},{-116,72},{-106,72}},                                                                                                             color={28,108,200}));
+  connect(HP_control_valve.C_out, HPT_P_in_sensor.C_in) annotation (Line(points={{-125,72},{-116,72},{-116,72},{-106,72}},                            color={28,108,200}));
   connect(HP_control_valve.Opening, HP_control_valve_opening_sensor.Opening) annotation (Line(points={{-130,80.7273},{-130,82},{-131,82},{-131,85.9}},
                                                                                                                                    color={0,0,127}));
   connect(HPT_1.C_out, HP_extract.C_in) annotation (Line(points={{-61,72},{-50.6,72}},           color={28,108,200}));
@@ -598,22 +597,18 @@ equation
   connect(HPT_1.C_W_out, generator.C_in) annotation (Line(points={{-61,78.72},{-54,78.72},{-54,168},{315.6,168}},     color={244,125,35}));
   connect(HPT_1.C_in, HPT_P_in_sensor.C_out) annotation (Line(points={{-79,72},{-94,72}},           color={28,108,200}));
   connect(HPT_P_out_sensor.C_in, HPT_2.C_out) annotation (Line(points={{26,72},{9,72}},            color={28,108,200}));
-  connect(steam_dryer.C_in, HPT_P_out_sensor.C_out) annotation (Line(points={{56,
-          91.2727},{56,92},{46,92},{46,72},{38,72}},                                                                               color={28,108,200}));
-  connect(superheater.C_cold_in, steam_dryer.C_hot_steam) annotation (Line(points={{72,104},
-          {72,91.2727}},                                                                                                color={28,108,200}));
+  connect(steam_dryer.C_in, HPT_P_out_sensor.C_out) annotation (Line(points={{56,91.2727},{56,92},{46,92},{46,72},{38,72}},        color={28,108,200}));
+  connect(superheater.C_cold_in, steam_dryer.C_hot_steam) annotation (Line(points={{72,104},{72,91.2727}},              color={28,108,200}));
   connect(superheater.C_hot_out, superheater_drains_P_sensor.C_in) annotation (Line(points={{88,112},{100,112}}, color={28,108,200}));
   connect(superheater_T_out_sensor.C_in,superheater. C_cold_out) annotation (Line(points={{88,130},{72,130},{72,120}},         color={28,108,200}));
-  connect(superheater_control_valve.C_in, HP_control_valve.C_in) annotation (Line(points={{-136,
-          112.182},{-136,112},{-158,112},{-158,72},{-135,72}},                                                                                          color={28,108,200}));
+  connect(superheater_control_valve.C_in, HP_control_valve.C_in) annotation (Line(points={{-136,112.182},{-136,112},{-158,112},{-158,72},{-135,72}},    color={28,108,200}));
   connect(superheater.C_hot_in, superheater_bleed_P_sensor.C_out) annotation (Line(points={{56,112},{-35,112},{-35,112.182},{-94,112.182}},     color={28,108,200}));
-  connect(superheater_bleed_P_sensor.C_in, superheater_control_valve.C_out) annotation (Line(points={{-106,
-          112.182},{-116,112.182},{-116,112.182},{-126,112.182}},                                                                                                  color={28,108,200}));
+  connect(superheater_bleed_P_sensor.C_in, superheater_control_valve.C_out) annotation (Line(points={{-106,112.182},{-116,112.182},{-116,112.182},{-126,112.182}}, color={28,108,200}));
   connect(LPT1.C_W_out, generator.C_in) annotation (Line(points={{169,136.72},{188,136.72},{188,168},{315.6,168}},   color={244,125,35}));
   connect(LPT2.C_W_out, generator.C_in) annotation (Line(points={{239,136.72},{262,136.72},{262,168},{315.6,168}},   color={244,125,35}));
   connect(LPT2.C_out, P_cond_sensor.C_in) annotation (Line(points={{239,130},{286,130}},                             color={28,108,200}));
-  connect(P_cond_sensor.C_out, condenser.C_hot_in) annotation (Line(points={{298,130},
-          {392.5,130},{392.5,74.2864}},                                                                    color={28,108,200}));
+  connect(P_cond_sensor.C_out, condenser.C_hot_in) annotation (Line(points={{298,130},{392.5,130},{392.5,74.2864}},
+                                                                                                           color={28,108,200}));
   connect(superheater_T_out_sensor.C_out, LPT1.C_in) annotation (Line(points={{100,130},{151,130}},                             color={28,108,200}));
   connect(extraction_pump.C_power, LP_pump_Wm_source.C_out) annotation (Line(points={{372,-61.36},{372,-50.8}}, color={244,125,35}));
   connect(extraction_pump.C_out, extraction_pump_T_out_sensor.C_in) annotation (Line(points={{364,-70},{350,-70}}, color={28,108,200}));
@@ -645,17 +640,12 @@ equation
   connect(superheater_drains_P_sensor.C_out, superheater_drains_pipe.C_in) annotation (Line(points={{112,112},{122,112},{122,40}}, color={28,108,200}));
   connect(superheater_drains_pipe.C_out, HP_heater.C_hot_in) annotation (Line(points={{122,20},{122,16},{-40,16},{-40,-62}}, color={28,108,200}));
   connect(HP_heater_T_out_sensor.C_out, Q_feedwater_sensor.C_in) annotation (Line(points={{-98,-70},{-104,-70}}, color={28,108,200}));
-  connect(HP_reheater_drains_control_valve.Opening, HP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{11,
-          -113.091},{11,-108.1}},                                                                                                                                 color={0,0,127}));
-  connect(HP_heater_T_drains_sensor.C_out, HP_reheater_drains_control_valve.C_in) annotation (Line(points={{-40,
-          -105},{-40,-121.818},{6,-121.818}},                                                                                                       color={28,108,200}));
-  connect(LP_reheater_drains_control_valve.Opening, LP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{293,
-          -111.091},{293,-106.1}},                                                                                                                                  color={0,0,127}));
-  connect(LP_heater.C_hot_out, LP_reheater_drains_control_valve.C_in) annotation (Line(points={{268,-78},
-          {268,-119.818},{288,-119.818}},                                                                                                color={28,108,200}));
+  connect(HP_reheater_drains_control_valve.Opening, HP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{11,-113.091},{11,-108.1}}, color={0,0,127}));
+  connect(HP_heater_T_drains_sensor.C_out, HP_reheater_drains_control_valve.C_in) annotation (Line(points={{-40,-105},{-40,-121.818},{6,-121.818}}, color={28,108,200}));
+  connect(LP_reheater_drains_control_valve.Opening, LP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{293,-111.091},{293,-106.1}}, color={0,0,127}));
+  connect(LP_heater.C_hot_out, LP_reheater_drains_control_valve.C_in) annotation (Line(points={{268,-78},{268,-119.818},{288,-119.818}}, color={28,108,200}));
   connect(steam_generator.steam_outlet, P_steam_sensor.C_in) annotation (Line(points={{-170,-24},{-170,3}},  color={28,108,200}));
-  connect(P_steam_sensor.C_out, HP_control_valve.C_in) annotation (Line(points={{-170,17},
-          {-170,72},{-135,72}},                                                                                           color={28,108,200}));
+  connect(P_steam_sensor.C_out, HP_control_valve.C_in) annotation (Line(points={{-170,17},{-170,72},{-135,72}},           color={28,108,200}));
   connect(superheater.C_vent, pressureCut.C_in) annotation (Line(points={{88,104.2},{88,86},{94,86}}, color={28,108,200}));
   connect(pressureCut.C_out, superheater_drains_pipe.C_in) annotation (Line(points={{114,86},{122,86},{122,40}}, color={28,108,200}));
   connect(cold_source.C_out, CW_T_in_sensor.C_in) annotation (Line(points={{305,67.7778},{305,67},{318,67}},                   color={28,108,200}));
@@ -663,13 +653,10 @@ equation
   connect(CW_P_in_sensor.C_out, condenser.C_cold_in) annotation (Line(points={{360,67},{378,67},{378,59.679},{377,59.679}},      color={28,108,200}));
   connect(CW_T_out_sensor.C_out, cold_sink.C_in) annotation (Line(points={{437,60},{455,60}},                                 color={28,108,200}));
   connect(condenser.C_cold_out, CW_T_out_sensor.C_in) annotation (Line(points={{407.69,59.679},{407.69,60},{423,60}},              color={28,108,200}));
-  connect(LP_reheater_drains_control_valve.C_out, condenser.C_hot_in) annotation (Line(points={{298,
-          -119.818},{400,-119.818},{400,-120},{500,-120},{500,100},{392.5,100},
-          {392.5,74.2864}},                                                                                                                                                       color={28,108,200}));
-  connect(HP_reheater_drains_control_valve.C_out, deaerator_outlet_pipe.C_in) annotation (Line(points={{16,
-          -121.818},{78,-121.818},{78,-122},{142,-122},{142,-70},{114,-70}},                                                                                                  color={28,108,200}));
-  connect(steam_generator.purge_outlet, Q_purge_sensor.C_in) annotation (Line(points={{-170,
-          -115.233},{-170,-125}},                                                                                               color={28,108,200}));
+  connect(LP_reheater_drains_control_valve.C_out, condenser.C_hot_in) annotation (Line(points={{298,-119.818},{400,-119.818},{400,-120},{500,-120},{500,100},{392.5,100},{392.5,74.2864}},
+                                                                                                                                                                                  color={28,108,200}));
+  connect(HP_reheater_drains_control_valve.C_out, deaerator_outlet_pipe.C_in) annotation (Line(points={{16,-121.818},{78,-121.818},{78,-122},{142,-122},{142,-70},{114,-70}}, color={28,108,200}));
+  connect(steam_generator.purge_outlet, Q_purge_sensor.C_in) annotation (Line(points={{-170,-115.233},{-170,-125}},             color={28,108,200}));
   connect(Q_feedwater_sensor.C_out, loopBreaker.C_in) annotation (Line(points={{-118,-70},{-132,-70}}, color={28,108,200}));
   connect(loopBreaker.C_out, steam_generator.feedwater_inlet) annotation (Line(points={{-152,-70},{-159,-70}}, color={28,108,200}));
   connect(Q_purge_sensor.C_out, sink.C_in) annotation (Line(points={{-170,-139},{-170,-145}}, color={28,108,200}));

--- a/MetroscopeModelingLibrary/Examples/Nuclear/MetroscopiaNPP/MetroscopiaNPP_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/Nuclear/MetroscopiaNPP/MetroscopiaNPP_reverse.mo
@@ -590,8 +590,7 @@ equation
   HP_reheater_drains_control_valve.Cv_max = HP_heater_drains_control_valve_Cvmax;
 
 
-  connect(HP_control_valve.C_out, HPT_P_in_sensor.C_in) annotation (Line(points={{-125,72},
-          {-116,72},{-116,72},{-106,72}},                                                                                                             color={28,108,200}));
+  connect(HP_control_valve.C_out, HPT_P_in_sensor.C_in) annotation (Line(points={{-125,72},{-116,72},{-116,72},{-106,72}},                            color={28,108,200}));
   connect(HP_control_valve.Opening, HP_control_valve_opening_sensor.Opening) annotation (Line(points={{-130,80.7273},{-130,82},{-131,82},{-131,85.9}},
                                                                                                                                    color={0,0,127}));
   connect(HPT_1.C_out, HP_extract.C_in) annotation (Line(points={{-61,72},{-50.6,72}},           color={28,108,200}));
@@ -605,22 +604,18 @@ equation
   connect(HPT_1.C_W_out, generator.C_in) annotation (Line(points={{-61,78.72},{-54,78.72},{-54,168},{315.6,168}},     color={244,125,35}));
   connect(HPT_1.C_in, HPT_P_in_sensor.C_out) annotation (Line(points={{-79,72},{-94,72}},           color={28,108,200}));
   connect(HPT_P_out_sensor.C_in, HPT_2.C_out) annotation (Line(points={{26,72},{9,72}},            color={28,108,200}));
-  connect(steam_dryer.C_in, HPT_P_out_sensor.C_out) annotation (Line(points={{56,
-          91.2727},{56,92},{46,92},{46,72},{38,72}},                                                                               color={28,108,200}));
-  connect(superheater.C_cold_in, steam_dryer.C_hot_steam) annotation (Line(points={{72,104},
-          {72,91.2727}},                                                                                                color={28,108,200}));
+  connect(steam_dryer.C_in, HPT_P_out_sensor.C_out) annotation (Line(points={{56,91.2727},{56,92},{46,92},{46,72},{38,72}},        color={28,108,200}));
+  connect(superheater.C_cold_in, steam_dryer.C_hot_steam) annotation (Line(points={{72,104},{72,91.2727}},              color={28,108,200}));
   connect(superheater.C_hot_out, superheater_drains_P_sensor.C_in) annotation (Line(points={{88,112},{100,112}}, color={28,108,200}));
   connect(superheater_T_out_sensor.C_in,superheater. C_cold_out) annotation (Line(points={{88,130},{72,130},{72,120}},         color={28,108,200}));
-  connect(superheater_control_valve.C_in, HP_control_valve.C_in) annotation (Line(points={{-136,
-          112.182},{-136,112},{-158,112},{-158,72},{-135,72}},                                                                                          color={28,108,200}));
+  connect(superheater_control_valve.C_in, HP_control_valve.C_in) annotation (Line(points={{-136,112.182},{-136,112},{-158,112},{-158,72},{-135,72}},    color={28,108,200}));
   connect(superheater.C_hot_in, superheater_bleed_P_sensor.C_out) annotation (Line(points={{56,112},{-35,112},{-35,112.182},{-94,112.182}},     color={28,108,200}));
-  connect(superheater_bleed_P_sensor.C_in, superheater_control_valve.C_out) annotation (Line(points={{-106,
-          112.182},{-116,112.182},{-116,112.182},{-126,112.182}},                                                                                                  color={28,108,200}));
+  connect(superheater_bleed_P_sensor.C_in, superheater_control_valve.C_out) annotation (Line(points={{-106,112.182},{-116,112.182},{-116,112.182},{-126,112.182}}, color={28,108,200}));
   connect(LPT1.C_W_out, generator.C_in) annotation (Line(points={{169,136.72},{188,136.72},{188,168},{315.6,168}},   color={244,125,35}));
   connect(LPT2.C_W_out, generator.C_in) annotation (Line(points={{239,136.72},{262,136.72},{262,168},{315.6,168}},   color={244,125,35}));
   connect(LPT2.C_out, P_cond_sensor.C_in) annotation (Line(points={{239,130},{286,130}},                             color={28,108,200}));
-  connect(P_cond_sensor.C_out, condenser.C_hot_in) annotation (Line(points={{298,130},
-          {392.5,130},{392.5,74.2864}},                                                                    color={28,108,200}));
+  connect(P_cond_sensor.C_out, condenser.C_hot_in) annotation (Line(points={{298,130},{392.5,130},{392.5,74.2864}},
+                                                                                                           color={28,108,200}));
   connect(superheater_T_out_sensor.C_out, LPT1.C_in) annotation (Line(points={{100,130},{151,130}},                             color={28,108,200}));
   connect(extraction_pump.C_power, LP_pump_Wm_source.C_out) annotation (Line(points={{372,-61.36},{372,-50.8}}, color={244,125,35}));
   connect(extraction_pump.C_out, extraction_pump_T_out_sensor.C_in) annotation (Line(points={{364,-70},{350,-70}}, color={28,108,200}));
@@ -652,17 +647,12 @@ equation
   connect(superheater_drains_P_sensor.C_out, superheater_drains_pipe.C_in) annotation (Line(points={{112,112},{122,112},{122,40}}, color={28,108,200}));
   connect(superheater_drains_pipe.C_out, HP_heater.C_hot_in) annotation (Line(points={{122,20},{122,16},{-40,16},{-40,-62}}, color={28,108,200}));
   connect(HP_heater_T_out_sensor.C_out, Q_feedwater_sensor.C_in) annotation (Line(points={{-98,-70},{-104,-70}}, color={28,108,200}));
-  connect(HP_reheater_drains_control_valve.Opening, HP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{11,
-          -113.091},{11,-108.1}},                                                                                                                                 color={0,0,127}));
-  connect(HP_heater_T_drains_sensor.C_out, HP_reheater_drains_control_valve.C_in) annotation (Line(points={{-40,
-          -105},{-40,-121.818},{6,-121.818}},                                                                                                       color={28,108,200}));
-  connect(LP_reheater_drains_control_valve.Opening, LP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{293,
-          -111.091},{293,-106.1}},                                                                                                                                  color={0,0,127}));
-  connect(LP_heater.C_hot_out, LP_reheater_drains_control_valve.C_in) annotation (Line(points={{268,-78},
-          {268,-119.818},{288,-119.818}},                                                                                                color={28,108,200}));
+  connect(HP_reheater_drains_control_valve.Opening, HP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{11,-113.091},{11,-108.1}}, color={0,0,127}));
+  connect(HP_heater_T_drains_sensor.C_out, HP_reheater_drains_control_valve.C_in) annotation (Line(points={{-40,-105},{-40,-121.818},{6,-121.818}}, color={28,108,200}));
+  connect(LP_reheater_drains_control_valve.Opening, LP_reheater_drains_control_valve_opening_sensor.Opening) annotation (Line(points={{293,-111.091},{293,-106.1}}, color={0,0,127}));
+  connect(LP_heater.C_hot_out, LP_reheater_drains_control_valve.C_in) annotation (Line(points={{268,-78},{268,-119.818},{288,-119.818}}, color={28,108,200}));
   connect(steam_generator.steam_outlet, P_steam_sensor.C_in) annotation (Line(points={{-170,-24},{-170,3}},  color={28,108,200}));
-  connect(P_steam_sensor.C_out, HP_control_valve.C_in) annotation (Line(points={{-170,17},
-          {-170,72},{-135,72}},                                                                                           color={28,108,200}));
+  connect(P_steam_sensor.C_out, HP_control_valve.C_in) annotation (Line(points={{-170,17},{-170,72},{-135,72}},           color={28,108,200}));
   connect(superheater.C_vent, pressureCut.C_in) annotation (Line(points={{88,104.2},{88,86},{94,86}}, color={28,108,200}));
   connect(pressureCut.C_out, superheater_drains_pipe.C_in) annotation (Line(points={{114,86},{122,86},{122,40}}, color={28,108,200}));
   connect(cold_source.C_out, CW_T_in_sensor.C_in) annotation (Line(points={{305,67.7778},{305,67},{318,67}},                   color={28,108,200}));
@@ -670,13 +660,10 @@ equation
   connect(CW_P_in_sensor.C_out, condenser.C_cold_in) annotation (Line(points={{360,67},{378,67},{378,59.679},{377,59.679}},      color={28,108,200}));
   connect(CW_T_out_sensor.C_out, cold_sink.C_in) annotation (Line(points={{437,60},{455,60}},                                 color={28,108,200}));
   connect(condenser.C_cold_out, CW_T_out_sensor.C_in) annotation (Line(points={{407.69,59.679},{407.69,60},{423,60}},              color={28,108,200}));
-  connect(LP_reheater_drains_control_valve.C_out, condenser.C_hot_in) annotation (Line(points={{298,
-          -119.818},{400,-119.818},{400,-120},{500,-120},{500,100},{392.5,100},
-          {392.5,74.2864}},                                                                                                                                                       color={28,108,200}));
-  connect(HP_reheater_drains_control_valve.C_out, deaerator_outlet_pipe.C_in) annotation (Line(points={{16,
-          -121.818},{78,-121.818},{78,-122},{142,-122},{142,-70},{114,-70}},                                                                                                  color={28,108,200}));
-  connect(steam_generator.purge_outlet, Q_purge_sensor.C_in) annotation (Line(points={{-170,
-          -115.233},{-170,-125}},                                                                                               color={28,108,200}));
+  connect(LP_reheater_drains_control_valve.C_out, condenser.C_hot_in) annotation (Line(points={{298,-119.818},{400,-119.818},{400,-120},{500,-120},{500,100},{392.5,100},{392.5,74.2864}},
+                                                                                                                                                                                  color={28,108,200}));
+  connect(HP_reheater_drains_control_valve.C_out, deaerator_outlet_pipe.C_in) annotation (Line(points={{16,-121.818},{78,-121.818},{78,-122},{142,-122},{142,-70},{114,-70}}, color={28,108,200}));
+  connect(steam_generator.purge_outlet, Q_purge_sensor.C_in) annotation (Line(points={{-170,-115.233},{-170,-125}},             color={28,108,200}));
   connect(Q_feedwater_sensor.C_out, loopBreaker.C_in) annotation (Line(points={{-118,-70},{-132,-70}}, color={28,108,200}));
   connect(loopBreaker.C_out, steam_generator.feedwater_inlet) annotation (Line(points={{-152,-70},{-159,-70}}, color={28,108,200}));
   connect(Q_purge_sensor.C_out, sink.C_in) annotation (Line(points={{-170,-139},{-170,-145}}, color={28,108,200}));

--- a/MetroscopeModelingLibrary/FlueGases/BaseClasses/FlowModel.mo
+++ b/MetroscopeModelingLibrary/FlueGases/BaseClasses/FlowModel.mo
@@ -6,7 +6,7 @@ model FlowModel
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation (IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0 = 1) annotation (IconMap(primitivesVisible=false));
 
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
   Inputs.InputPower W_input(start=0);

--- a/MetroscopeModelingLibrary/FlueGases/BaseClasses/IsoHFlowModel.mo
+++ b/MetroscopeModelingLibrary/FlueGases/BaseClasses/IsoHFlowModel.mo
@@ -6,7 +6,7 @@ model IsoHFlowModel
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation (IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0=1) annotation (IconMap(primitivesVisible=false));
 
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
   Inputs.InputDifferentialPressure DP_input(start=0);

--- a/MetroscopeModelingLibrary/FlueGases/BaseClasses/IsoPFlowModel.mo
+++ b/MetroscopeModelingLibrary/FlueGases/BaseClasses/IsoPFlowModel.mo
@@ -6,7 +6,7 @@ model IsoPFlowModel
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation (IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0=1) annotation (IconMap(primitivesVisible=false));
 
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
   Inputs.InputPower W_input(start=0);

--- a/MetroscopeModelingLibrary/FlueGases/BaseClasses/IsoPHFlowModel.mo
+++ b/MetroscopeModelingLibrary/FlueGases/BaseClasses/IsoPHFlowModel.mo
@@ -6,5 +6,5 @@ model IsoPHFlowModel
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation (IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0=1) annotation (IconMap(primitivesVisible=false));
 end IsoPHFlowModel;

--- a/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
@@ -5,7 +5,7 @@ model AirCompressor
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation (IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0 = 1) annotation (IconMap(primitivesVisible=false));
 
   package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
 

--- a/MetroscopeModelingLibrary/FlueGases/Machines/GasTurbine.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Machines/GasTurbine.mo
@@ -5,7 +5,7 @@ model GasTurbine
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation (IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0 = 1) annotation (IconMap(primitivesVisible=false));
 
   package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
 

--- a/MetroscopeModelingLibrary/FlueGases/Pipes/ControlValve.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Pipes/ControlValve.mo
@@ -5,7 +5,7 @@ model ControlValve
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation(IconMap(primitivesVisible=false));
+    Q_0 = 500, rho_0 = 1) annotation(IconMap(primitivesVisible=false));
   annotation (Icon(graphics={
         Polygon(
           points={{40,102},{-40,102},{-40,118},{-38,136},{-32,146},{-20,156},{0,162},{20,156},{32,146},{38,134},{40,116},{40,102}},

--- a/MetroscopeModelingLibrary/FlueGases/Pipes/HeatLoss.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Pipes/HeatLoss.mo
@@ -5,7 +5,7 @@ model HeatLoss
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 500, rho_in(start=1), rho_out(start=1), rho(start=1))
+    Q_0 = 500, rho_0=1)
     annotation(IconMap(primitivesVisible=false));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
                                Rectangle(

--- a/MetroscopeModelingLibrary/FlueGases/Pipes/Pipe.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Pipes/Pipe.mo
@@ -6,7 +6,7 @@ model Pipe
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare package Medium = FlueGasesMedium,
-    Q_0 = 50, rho_in(start=1), rho_out(start=1), rho(start=1)) annotation(IconMap(primitivesVisible=false));
+    Q_0 = 50, rho_0=1) annotation(IconMap(primitivesVisible=false));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
                                Rectangle(
           extent={{-100,30},{100,-30}},

--- a/MetroscopeModelingLibrary/Partial/Pipes/ControlValve.mo
+++ b/MetroscopeModelingLibrary/Partial/Pipes/ControlValve.mo
@@ -17,7 +17,7 @@ partial model ControlValve
 
 equation
   /* Pressure loss */
-  DP*Cv*abs(Cv) = -1.733e12*Q^2/(time*rho_in + (1-time)*rho)^2;
+  DP*Cv*abs(Cv) = -1.733e12*Q^2/rho_in^2;
   /* Cv as a function of the valve position */
   Cv =Opening*Cv_max;
 

--- a/MetroscopeModelingLibrary/Partial/Pipes/ControlValve.mo
+++ b/MetroscopeModelingLibrary/Partial/Pipes/ControlValve.mo
@@ -17,7 +17,7 @@ partial model ControlValve
 
 equation
   /* Pressure loss */
-  DP*Cv*abs(Cv) = -1.733e12*Q^2/rho^2;
+  DP*Cv*abs(Cv) = -1.733e12*Q^2/(time*rho_in + (1-time)*rho)^2;
   /* Cv as a function of the valve position */
   Cv =Opening*Cv_max;
 

--- a/MetroscopeModelingLibrary/Partial/Pipes/Pipe.mo
+++ b/MetroscopeModelingLibrary/Partial/Pipes/Pipe.mo
@@ -10,9 +10,6 @@ partial model Pipe
   Units.DifferentialPressure DP_f "Singular pressure loss";
   Units.DifferentialPressure DP_z "Singular pressure loss";
 
-  Units.DifferentialPressure DP_f_old "Singular pressure loss";
-  Units.DifferentialPressure DP_z_old "Singular pressure loss";
-
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling; // Fouling coefficient
@@ -24,13 +21,10 @@ equation
     fouling = 0;
   end if;
 
-  DP_f_old = - (1+ fouling/100)*Kfr*Q*abs(Q)/rho;
-  DP_z_old = - rho*Constants.g*delta_z;
-
   DP_f = - (1+ fouling/100)*Kfr*Q*abs(Q)/rho_in;
   DP_z = - rho_in*Constants.g*delta_z;
 
-  DP = time * (DP_f + DP_z) + (1-time)*(DP_f_old+DP_z_old);
+  DP = DP_f + DP_z;
   annotation (
     Diagram(coordinateSystem(
         preserveAspectRatio=true,

--- a/MetroscopeModelingLibrary/Partial/Pipes/Pipe.mo
+++ b/MetroscopeModelingLibrary/Partial/Pipes/Pipe.mo
@@ -10,6 +10,9 @@ partial model Pipe
   Units.DifferentialPressure DP_f "Singular pressure loss";
   Units.DifferentialPressure DP_z "Singular pressure loss";
 
+  Units.DifferentialPressure DP_f_old "Singular pressure loss";
+  Units.DifferentialPressure DP_z_old "Singular pressure loss";
+
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling; // Fouling coefficient
@@ -21,10 +24,13 @@ equation
     fouling = 0;
   end if;
 
-  DP_f = - (1+ fouling/100)*Kfr*Q*abs(Q)/rho;
-  DP_z = - rho*Constants.g*delta_z;
+  DP_f_old = - (1+ fouling/100)*Kfr*Q*abs(Q)/rho;
+  DP_z_old = - rho*Constants.g*delta_z;
 
-  DP = DP_f + DP_z;
+  DP_f = - (1+ fouling/100)*Kfr*Q*abs(Q)/rho_in;
+  DP_z = - rho_in*Constants.g*delta_z;
+
+  DP = time * (DP_f + DP_z) + (1-time)*(DP_f_old+DP_z_old);
   annotation (
     Diagram(coordinateSystem(
         preserveAspectRatio=true,

--- a/MetroscopeModelingLibrary/Partial/Pipes/SlideValve.mo
+++ b/MetroscopeModelingLibrary/Partial/Pipes/SlideValve.mo
@@ -17,7 +17,7 @@ equation
   end if;
 
   /* Pressure loss */
-  DP*(1 - closed_valve/100)^2*Cv*abs(Cv) = -1.733e12*Q^2/rho^2;
+  DP*(1 - closed_valve/100)^2*Cv*abs(Cv) = -1.733e12*Q^2/rho_in^2;
 
 
   annotation (


### PR DESCRIPTION
## Goal

This PR fixes the pressure loss complexity by using the inlet density instead of the mean density. Mean density created a complexity in which the pressure drop depends on the temperature, which creates a non desired causality possibility. This change is done in Pipes, ControlValves and SlidingValves. 

No variables were deleted from the library, so the changes are transparent in terms of convergence (unless the model was using this weird causality). 

For already calibrated models, results will slightly change. Most tests of the library were not significantly impacted by this, except some control valves of the steam turbine. This is therefore considered a breaking change but could be transparent for most models. 

Fix #427 

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [x] Breaking change (See above)
- [ ] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [x] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
