### PR TITLE
Sensor background colors

### DIFF
--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
@@ -1,4 +1,4 @@
-﻿within MetroscopeModelingLibrary.Examples.CCGT.MetroscopiaCCGT;
+within MetroscopeModelingLibrary.Examples.CCGT.MetroscopiaCCGT;
 model MetroscopiaCCGT_reverse
   import MetroscopeModelingLibrary.Utilities.Units;
 
@@ -139,29 +139,29 @@ model MetroscopiaCCGT_reverse
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={222,198})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_eco_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_eco_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=180,
         origin={8,8})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_eco_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_eco_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=180,
         origin={56,8})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Evaporator evaporator
     annotation (Placement(transformation(extent={{-46,-56},{12,4.5}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_evap_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_evap_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-34,2},{-46,14}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater1(
       QCp_max_side=HPSH_QCp_max_side)
     annotation (Placement(transformation(extent={{-186,-56},{-126,4}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH1_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH1_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=180,
         origin={-184,8})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_HPSH1_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_HPSH1_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=180,
@@ -169,19 +169,19 @@ model MetroscopiaCCGT_reverse
   WaterSteam.Pipes.SlideValve                             HPST_control_valve
     annotation (Placement(transformation(extent={{-203.25,144.738},{-186.75,
             162.677}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_HPST_in_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_HPST_in_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=0,
         origin={-174,148})));
   MetroscopeModelingLibrary.WaterSteam.Machines.SteamTurbine HPsteamTurbine annotation (Placement(transformation(extent={{-160,132},{-126,164}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_HPST_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_HPST_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-114,142},{-102,154}})));
-  MetroscopeModelingLibrary.Sensors.Power.PowerSensor W_ST_out_sensor
+  MetroscopeModelingLibrary.Sensors.Power.PowerSensor W_ST_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{90,250},{102,262}})));
   MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser
     annotation (Placement(transformation(extent={{32,144.778},{72,176.778}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_circulating_water_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_circulating_water_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{86,171},{96,181}})));
   MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source circulating_water_source
     annotation (Placement(transformation(
@@ -195,12 +195,12 @@ model MetroscopiaCCGT_reverse
         extent={{-7,-7},{7,7}},
         origin={116,131},
         rotation=0)));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_pump_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_pump_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
-        extent={{5,-5},{-5,5}},
+        extent={{5,5},{-5,-5}},
         rotation=180,
         origin={137,131})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_pump_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_pump_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-5,-5},{5,5}}, origin={155,
             131})));
   MetroscopeModelingLibrary.Power.BoundaryConditions.Source powerSource
@@ -213,7 +213,7 @@ model MetroscopiaCCGT_reverse
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={182,28})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.FlowSensor Q_pump_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.FlowSensor Q_pump_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{166,126},{176,136}})));
   MetroscopeModelingLibrary.FlueGases.Machines.AirCompressor airCompressor(h_out(
         start=7e5))
@@ -232,49 +232,49 @@ model MetroscopiaCCGT_reverse
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={-442,-90})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor compressor_P_out_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor compressor_P_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-490,-32},{-478,-20}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor compressor_T_out_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor compressor_T_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-472,-32},{-460,-20}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor turbine_P_out_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor turbine_P_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-350,-32},{-338,-20}})));
-  MetroscopeModelingLibrary.Sensors.Power.PowerSensor W_GT_sensor
+  MetroscopeModelingLibrary.Sensors.Power.PowerSensor W_GT_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-346,28},{-334,40}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor turbine_T_out_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor turbine_T_out_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-370,-32},{-358,-20}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater Reheater(
       QCp_max_side=ReH_QCp_max_side)
     annotation (Placement(transformation(extent={{-102,-56},{-42,4}})));
   MetroscopeModelingLibrary.WaterSteam.Machines.SteamTurbine LPsteamTurbine annotation (Placement(transformation(extent={{-14,198},{20,230}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_ReH_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_ReH_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{6,-6},{-6,6}},
         rotation=270,
         origin={-80,29})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_ReH_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_ReH_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=90,
         origin={-80,49})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_Cond_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_Cond_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{28,208},{40,220}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_source_air_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_source_air_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-636,-32},{-624,-20}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor T_source_air_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor T_source_air_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-618,-32},{-606,-20}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.FlowSensor Q_source_air_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.FlowSensor Q_source_air_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-600,-32},{-588,-20}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_circulating_water_in_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_circulating_water_in_sensor(sensor_function="BC")
     annotation (Placement(transformation(
-        extent={{5,-5},{-5,5}},
+        extent={{5,5},{-5,-5}},
         rotation=180,
         origin={3,159})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_circulating_water_in_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_circulating_water_in_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-5,-5},{5,5}}, origin={19,159})));
   WaterSteam.Pipes.SlideValve                             LPST_control_valve
     annotation (Placement(transformation(extent={{-61.25,210.738},{-44.75,
             228.677}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_LPST_in_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_LPST_in_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=0,
@@ -289,38 +289,38 @@ model MetroscopiaCCGT_reverse
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={94,66})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_pumpRec_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_pumpRec_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{5,-5},{-5,5}},
         rotation=180,
         origin={115,48.5455})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_pumpRec_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_pumpRec_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-5,-5},{5,5}}, origin={131,
             48.5455})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.FlowSensor Q_pumpRec_out_sensor
     annotation (Placement(transformation(extent={{140,43.5455},{150,53.5455}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_eco_in_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_eco_in_sensor(sensor_function="BC")
     annotation (Placement(transformation(
         extent={{-5,-5},{5,5}},
         rotation=180,
         origin={145,9})));
   MetroscopeModelingLibrary.WaterSteam.Pipes.ControlValve pumpRec_controlValve
     annotation (Placement(transformation(extent={{157,46},{170,60}})));
-  MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor pumpRec_opening_sensor
+  MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor pumpRec_opening_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{158,68},{168,78}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_flue_gas_sink_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_flue_gas_sink_sensor(sensor_function="BC")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=90,
         origin={222,172})));
   MetroscopeModelingLibrary.Power.BoundaryConditions.Sink sink
     annotation (Placement(transformation(extent={{110,246},{130,266}})));
-  MetroscopeModelingLibrary.Sensors.Fuel.PressureSensor P_fuel_source_sensor
+  MetroscopeModelingLibrary.Sensors.Fuel.PressureSensor P_fuel_source_sensor(sensor_function="BC")
     annotation (Placement(transformation(
         extent={{-5,-5},{5,5}},
         rotation=90,
         origin={-442,-61})));
-  MetroscopeModelingLibrary.Sensors.Fuel.TemperatureSensor T_fuel_source_sensor
+  MetroscopeModelingLibrary.Sensors.Fuel.TemperatureSensor T_fuel_source_sensor(sensor_function="BC")
     annotation (Placement(transformation(
         extent={{-5,-5},{5,5}},
         rotation=90,
@@ -341,17 +341,17 @@ model MetroscopiaCCGT_reverse
         origin={170,-26})));
   MetroscopeModelingLibrary.FlueGases.Pipes.Filter AirFilter
     annotation (Placement(transformation(extent={{-576,-36},{-556,-16}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_filter_out_sensor
+  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_filter_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-548,-32},{-536,-20}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater2(
       QCp_max_side=HPSH_QCp_max_side)
     annotation (Placement(transformation(extent={{-302,-56},{-242,4}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH2_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH2_out_sensor(sensor_function="BC")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=90,
         origin={-282,34})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_HPSH2_out_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_HPSH2_out_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=90,
@@ -359,17 +359,18 @@ model MetroscopiaCCGT_reverse
   MetroscopeModelingLibrary.WaterSteam.Pipes.ControlValve deSH_controlValve
     annotation (Placement(transformation(extent={{-158.75,89.4545},{-171.25,
             103.455}})));
-  MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor deSH_opening_sensor
+  MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor deSH_opening_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-170,114},{-160,124}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.FlowSensor Q_deSH_sensor
+  MetroscopeModelingLibrary.Sensors.WaterSteam.FlowSensor Q_deSH_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{-132,86},{-144,98}})));
   MetroscopeModelingLibrary.WaterSteam.Pipes.ControlValve Evap_controlValve
     annotation (Placement(transformation(extent={{41.25,5.4545},{28.75,19.455}})));
-  MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor Evap_opening_sensor
+  MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor Evap_opening_sensor(sensor_function="Calibration")
     annotation (Placement(transformation(extent={{30,34},{40,44}})));
   MetroscopeModelingLibrary.MultiFluid.Converters.MoistAir_to_FlueGases moistAir_to_FlueGases annotation (Placement(transformation(extent={{-672,-36},{-652,-16}})));
   MetroscopeModelingLibrary.MoistAir.BoundaryConditions.Source source_air(h_out(start=47645.766)) annotation (Placement(transformation(extent={{-708,-36},{-688,-16}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_HPST_out_sensor annotation (Placement(transformation(
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_HPST_out_sensor(sensor_function="Calibration")
+                                                                                   annotation (Placement(transformation(
         extent={{6,-6},{-6,6}},
         rotation=180,
         origin={-90,148})));
@@ -802,110 +803,10 @@ equation
           pattern=LinePattern.None,
           fillColor={158,158,158},
           fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-638,-18},{-586,-34}},
-          fillColor={255,82,82},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None),
-        Rectangle(
-          extent={{-14,7},{14,-7}},
-          fillColor={255,82,82},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          origin={-443,-68},
-          rotation=-90),
-        Rectangle(
-          extent={{-15,7},{15,-7}},
-          fillColor={255,82,82},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          origin={11,159},
-          rotation=360),
-        Rectangle(
-          extent={{-8,8},{8,-8}},
-          fillColor={255,82,82},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          origin={222,172},
-          rotation=360),
-        Rectangle(
-          extent={{-372,-18},{-356,-34}},
-          pattern=LinePattern.None,
-          fillColor={0,140,72},
-          fillPattern=FillPattern.Solid,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{138,16},{152,2}},
-          pattern=LinePattern.None,
-          fillColor={0,140,72},
-          fillPattern=FillPattern.Solid,
-          lineColor={0,0,0}),
-        Rectangle(
-          extent={{-450,-40},{-436,-54}},
-          lineColor={0,0,0},
-          pattern=LinePattern.None,
-          fillColor={244,237,30},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{138,56},{152,42}},
-          lineColor={0,0,0},
-          pattern=LinePattern.None,
-          fillColor={244,237,30},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{162,-18},{178,-34}},
-          lineColor={0,0,0},
-          pattern=LinePattern.None,
-          fillColor={244,237,30},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-290,42},{-274,26}},
-          pattern=LinePattern.None,
-          fillColor={0,140,72},
-          fillPattern=FillPattern.Solid,
-          lineColor={0,0,0}),
         Text(
           extent={{-230,96},{-174,96}},
           textColor={28,108,200},
-          textString="Desuperheater"),
-        Rectangle(
-          extent={{-10,10},{10,-10}},
-          fillColor={255,82,82},
-          fillPattern=FillPattern.Solid,
-          pattern=LinePattern.None,
-          origin={-670,248},
-          rotation=360),
-        Text(
-          extent={{-650,253},{-564,243}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          textString="Boundary Conditions",
-          fontSize=8),
-        Rectangle(
-          extent={{-680,232},{-660,212}},
-          pattern=LinePattern.None,
-          fillColor={0,140,72},
-          fillPattern=FillPattern.Solid,
-          lineColor={0,0,0}),
-        Text(
-          extent={{-650,227},{-564,217}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          textString="Control Parameters",
-          fontSize=8),
-        Rectangle(
-          extent={{-680,206},{-660,186}},
-          lineColor={0,0,0},
-          pattern=LinePattern.None,
-          fillColor={244,237,30},
-          fillPattern=FillPattern.Solid),
-        Text(
-          extent={{-650,204},{-476,188}},
-          textColor={0,0,0},
-          horizontalAlignment=TextAlignment.Left,
-          fontSize=8,
-          textString="Observables not used for calibration"),
-                                          Text(
+          textString="Desuperheater"),    Text(
           extent={{-306,-48},{-244,-54}},
           textColor={0,0,0},
           textStyle={TextStyle.Bold},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FlueGasesSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FlueGasesSensorIcon.mo
@@ -1,15 +1,25 @@
 within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record FlueGasesSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
+
+  parameter Boolean BC = false "True if the sensor is a boundary condition";
+  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+
   annotation (Icon(
       graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          pattern=LinePattern.None,
+          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
+          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
         Ellipse(
-          extent={{-100,100},{100,-98}},
+          extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           fillColor={95,95,95},
           fillPattern=FillPattern.Solid),
         Ellipse(
-          extent={{-80,81},{80,-79}},
+          extent={{-80,80},{80,-80}},
           lineColor={0,0,0},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid,

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FlueGasesSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FlueGasesSensorIcon.mo
@@ -2,8 +2,8 @@ within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record FlueGasesSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
 
-  parameter Boolean BC = false "True if the sensor is a boundary condition";
-  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+  parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
+    annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
 
   annotation (Icon(
       graphics={
@@ -11,8 +11,8 @@ partial record FlueGasesSensorIcon "should be extended in partial base classes"
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           pattern=LinePattern.None,
-          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
-          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
+          fillColor=if sensor_function == "BC" then {238, 46, 47} elseif sensor_function == "Calibration" then {107, 175, 17} else {255, 255, 255},
+          fillPattern=if sensor_function == "BC" or sensor_function == "Calibration" then FillPattern.Solid else FillPattern.None),
         Ellipse(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FuelSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FuelSensorIcon.mo
@@ -2,8 +2,8 @@ within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record FuelSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
 
-  parameter Boolean BC = false "True if the sensor is a boundary condition";
-  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+  parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
+    annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
 
   annotation (Icon(
       graphics={
@@ -11,8 +11,8 @@ partial record FuelSensorIcon "should be extended in partial base classes"
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           pattern=LinePattern.None,
-          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
-          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
+          fillColor=if sensor_function == "BC" then {238, 46, 47} elseif sensor_function == "Calibration" then {107, 175, 17} else {255, 255, 255},
+          fillPattern=if sensor_function == "BC" or sensor_function == "Calibration" then FillPattern.Solid else FillPattern.None),
         Ellipse(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FuelSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/FuelSensorIcon.mo
@@ -1,15 +1,25 @@
 within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record FuelSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
+
+  parameter Boolean BC = false "True if the sensor is a boundary condition";
+  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+
   annotation (Icon(
       graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          pattern=LinePattern.None,
+          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
+          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
         Ellipse(
-          extent={{-100,100},{100,-98}},
+          extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           fillColor={213,213,0},
           fillPattern=FillPattern.Solid),
         Ellipse(
-          extent={{-80,81},{80,-79}},
+          extent={{-80,80},{80,-80}},
           lineColor={0,0,0},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid,

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/InlineSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/InlineSensorIcon.mo
@@ -4,13 +4,13 @@ partial record InlineSensorIcon "should be extended in partial base classes"
   annotation (Icon(
       graphics={
         Ellipse(
-          extent={{-100,100},{100,-98}},
+          extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           fillColor={0,0,0},
           fillPattern=FillPattern.Solid,
           lineThickness=0.5),
         Ellipse(
-          extent={{-80,81},{80,-79}},
+          extent={{-80,80},{80,-80}},
           lineColor={0,0,0},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid)}));

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/MoistAirSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/MoistAirSensorIcon.mo
@@ -2,8 +2,8 @@ within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record MoistAirSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
 
-  parameter Boolean BC = false "True if the sensor is a boundary condition";
-  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+  parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
+    annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
 
   annotation (Icon(
       graphics={
@@ -11,8 +11,8 @@ partial record MoistAirSensorIcon "should be extended in partial base classes"
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           pattern=LinePattern.None,
-          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
-          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
+          fillColor=if sensor_function == "BC" then {238, 46, 47} elseif sensor_function == "Calibration" then {107, 175, 17} else {255, 255, 255},
+          fillPattern=if sensor_function == "BC" or sensor_function == "Calibration" then FillPattern.Solid else FillPattern.None),
         Ellipse(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/MoistAirSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/MoistAirSensorIcon.mo
@@ -1,15 +1,25 @@
 within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record MoistAirSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
+
+  parameter Boolean BC = false "True if the sensor is a boundary condition";
+  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+
   annotation (Icon(
       graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          pattern=LinePattern.None,
+          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
+          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
         Ellipse(
-          extent={{-100,100},{100,-98}},
+          extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           fillColor={85,170,255},
           fillPattern=FillPattern.Solid),
         Ellipse(
-          extent={{-80,81},{80,-79}},
+          extent={{-80,80},{80,-80}},
           lineColor={0,0,0},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid,

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/OutlineSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/OutlineSensorIcon.mo
@@ -1,8 +1,18 @@
 within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record OutlineSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
+
+  parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
+    annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
+
   annotation (Icon(
       graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          pattern=LinePattern.None,
+          fillColor=if sensor_function == "BC" then {238, 46, 47} elseif sensor_function == "Calibration" then {107, 175, 17} else {255, 255, 255},
+          fillPattern=if sensor_function == "BC" or sensor_function == "Calibration" then FillPattern.Solid else FillPattern.None),
         Ellipse(
           extent={{-100,100},{100,-98}},
           lineColor={0,0,0},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/PowerSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/PowerSensorIcon.mo
@@ -2,8 +2,8 @@ within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record PowerSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
 
-  parameter Boolean BC = false "True if the sensor is a boundary condition";
-  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+  parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
+    annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
 
   annotation (Icon(
       graphics={
@@ -11,8 +11,8 @@ partial record PowerSensorIcon "should be extended in partial base classes"
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           pattern=LinePattern.None,
-          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
-          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
+          fillColor=if sensor_function == "BC" then {238, 46, 47} elseif sensor_function == "Calibration" then {107, 175, 17} else {255, 255, 255},
+          fillPattern=if sensor_function == "BC" or sensor_function == "Calibration" then FillPattern.Solid else FillPattern.None),
         Ellipse(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/PowerSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/PowerSensorIcon.mo
@@ -1,15 +1,25 @@
 within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record PowerSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
+
+  parameter Boolean BC = false "True if the sensor is a boundary condition";
+  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+
   annotation (Icon(
       graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          pattern=LinePattern.None,
+          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
+          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
         Ellipse(
-          extent={{-100,100},{100,-98}},
+          extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           fillColor={244,125,35},
           fillPattern=FillPattern.Solid),
         Ellipse(
-          extent={{-80,81},{80,-79}},
+          extent={{-80,80},{80,-80}},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid,
           pattern=LinePattern.None),

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/WaterSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/WaterSensorIcon.mo
@@ -2,8 +2,8 @@ within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record WaterSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
 
-  parameter Boolean BC = false "True if the sensor is a boundary condition";
-  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+  parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
+    annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
 
   annotation (Icon(
       graphics={
@@ -11,8 +11,8 @@ partial record WaterSensorIcon "should be extended in partial base classes"
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           pattern=LinePattern.None,
-          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
-          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
+          fillColor=if sensor_function == "BC" then {238, 46, 47} elseif sensor_function == "Calibration" then {107, 175, 17} else {255, 255, 255},
+          fillPattern=if sensor_function == "BC" or sensor_function == "Calibration" then FillPattern.Solid else FillPattern.None),
         Ellipse(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,0},

--- a/MetroscopeModelingLibrary/Utilities/Icons/Sensors/WaterSensorIcon.mo
+++ b/MetroscopeModelingLibrary/Utilities/Icons/Sensors/WaterSensorIcon.mo
@@ -1,15 +1,25 @@
 within MetroscopeModelingLibrary.Utilities.Icons.Sensors;
 partial record WaterSensorIcon "should be extended in partial base classes"
   extends MetroscopeModelingLibrary.Utilities.Icons.KeepingScaleIcon;
+
+  parameter Boolean BC = false "True if the sensor is a boundary condition";
+  parameter Boolean no_calibration = false "True is the sensor is not used for calibration";
+
   annotation (Icon(
       graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          pattern=LinePattern.None,
+          fillColor=if BC then {238, 46, 47} elseif no_calibration then {0,140,72} else {255, 255, 255},
+          fillPattern=if BC or no_calibration then FillPattern.Solid else FillPattern.None),
         Ellipse(
-          extent={{-100,100},{100,-98}},
+          extent={{-100,100},{100,-100}},
           lineColor={0,0,0},
           fillColor={28,108,200},
           fillPattern=FillPattern.Solid),
         Ellipse(
-          extent={{-80,81},{80,-79}},
+          extent={{-80,80},{80,-80}},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid,
           pattern=LinePattern.None),


### PR DESCRIPTION
## Goal

Added a parameter `sensor_function` in the sensors icons with dropdown list of three options, `Unidentified`, `BC` and `Calibration`.
This will make the application of the colors standards in the diagrams easier.

I applied it only on Metroscopia CCGT reverse example (to be applied on all tests and examples)


## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
