### PR TITLE
New feature to display simulation outputs on model diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 ## [Unreleased]
 
 ### ✨ Added <!--Make sure to add a link to the PR and issues related to your change-->
+- Added a deature to display simulation outputs on the models' diagrams [#482](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/482)
 
 ### 🐛 Fixed <!--Make sure to add a link to the PR and issues related to your change-->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 ## [Unreleased]
 
 ### ✨ Added <!--Make sure to add a link to the PR and issues related to your change-->
-- Added a deature to display simulation outputs on the models' diagrams [#482](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/482)
+- New feature to display simulation outputs on model diagrams [#482](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/482)
 
 ### 🐛 Fixed <!--Make sure to add a link to the PR and issues related to your change-->
 

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
@@ -345,7 +345,7 @@ model MetroscopiaCCGT_reverse
   MetroscopeModelingLibrary.FlueGases.Pipes.Filter AirFilter
     annotation (Placement(transformation(extent={{-576,-36},{-556,-16}})));
   MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_filter_out_sensor(
-    display_unit="MPaA",                                                         sensor_function="Calibration", causality="filter_Kfr")
+    display_unit="mbar",                                                         sensor_function="Calibration", causality="filter_Kfr")
     annotation (Placement(transformation(extent={{-548,-32},{-536,-20}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater2(
       QCp_max_side=HPSH_QCp_max_side)

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
@@ -3,6 +3,7 @@ model MetroscopiaCCGT_reverse
   import MetroscopeModelingLibrary.Utilities.Units;
 
   inner parameter Boolean show_causality = true "true to show causality, false to hide it";
+  inner parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
   // Boundary conditions
 
@@ -233,7 +234,7 @@ model MetroscopiaCCGT_reverse
         start=0.9e6)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={-442,-90})));
+        origin={-442,-110})));
   MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor compressor_P_out_sensor(sensor_function="Calibration", causality="compressor_tau")
     annotation (Placement(transformation(extent={{-490,-32},{-478,-20}})));
   MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor compressor_T_out_sensor(sensor_function="Calibration", causality="compressor_eta_is")
@@ -303,7 +304,7 @@ model MetroscopiaCCGT_reverse
     annotation (Placement(transformation(extent={{140,43.5455},{150,53.5455}})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_eco_in_sensor(sensor_function="BC")
     annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
+        extent={{-5,5},{5,-5}},
         rotation=180,
         origin={145,9})));
   MetroscopeModelingLibrary.WaterSteam.Pipes.ControlValve pumpRec_controlValve
@@ -343,12 +344,13 @@ model MetroscopiaCCGT_reverse
         origin={170,-26})));
   MetroscopeModelingLibrary.FlueGases.Pipes.Filter AirFilter
     annotation (Placement(transformation(extent={{-576,-36},{-556,-16}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_filter_out_sensor(sensor_function="Calibration", causality="filter_Kfr")
+  MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_filter_out_sensor(
+    display_unit="MPaA",                                                         sensor_function="Calibration", causality="filter_Kfr")
     annotation (Placement(transformation(extent={{-548,-32},{-536,-20}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater2(
       QCp_max_side=HPSH_QCp_max_side)
     annotation (Placement(transformation(extent={{-302,-56},{-242,4}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH2_out_sensor(sensor_function="BC")
+  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH2_out_sensor(sensor_function="BC", display_unit="degC")
     annotation (Placement(transformation(
         extent={{-6,-6},{6,6}},
         rotation=90,
@@ -370,12 +372,19 @@ model MetroscopiaCCGT_reverse
   MetroscopeModelingLibrary.Sensors.Outline.OpeningSensor Evap_opening_sensor(sensor_function="Calibration", causality="Cvmax")
     annotation (Placement(transformation(extent={{30,34},{40,44}})));
   MetroscopeModelingLibrary.MultiFluid.Converters.MoistAir_to_FlueGases moistAir_to_FlueGases annotation (Placement(transformation(extent={{-672,-36},{-652,-16}})));
-  MetroscopeModelingLibrary.MoistAir.BoundaryConditions.Source source_air(h_out(start=47645.766)) annotation (Placement(transformation(extent={{-708,-36},{-688,-16}})));
+  MetroscopeModelingLibrary.MoistAir.BoundaryConditions.Source source_air(h_out(start=47645.766)) annotation (Placement(transformation(extent={{-720,-36},{-700,-16}})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_HPST_out_sensor(sensor_function="Calibration", causality="HPST_eta_is")
                                                                                    annotation (Placement(transformation(
         extent={{6,6},{-6,-6}},
         rotation=180,
         origin={-90,148})));
+  Sensors.Displayer.WaterDisplayer displayer annotation (Placement(transformation(extent={{-248,138},{-228,158}})));
+  Sensors.Displayer.FuelDisplayer fuelDisplayer annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-442,-92})));
+  Sensors.Displayer.MoistAirDisplayer moistAirDisplayer annotation (Placement(transformation(extent={{-700,-36},{-680,-16}})));
+  Sensors.Displayer.FlueGasesDisplayer flueGasesDisplayer annotation (Placement(transformation(extent={{-654,-36},{-634,-16}})));
 equation
 
   //--- Air / Flue Gas System ---
@@ -384,7 +393,7 @@ equation
       // Quantities definition
       P_source_air_sensor.P_barA = P_source_air;
       T_source_air_sensor.T_degC = T_source_air;
-      Q_source_air_sensor.Q = Q_source_air;
+      Q_source_air_sensor.Q = Q_source_air + 10*time;
       source_air.relative_humidity=Relative_Humidity;
 
     // Fuel Source
@@ -710,8 +719,6 @@ equation
   connect(P_fuel_source_sensor.C_in, T_fuel_source_sensor.C_out) annotation (
       Line(points={{-442,-66},{-442,-68},{-442,-68},{-442,-70}}, color={213,213,
           0}));
-  connect(source_fuel.C_out, T_fuel_source_sensor.C_in)
-    annotation (Line(points={{-442,-85},{-442,-80}}, color={213,213,0}));
   connect(GT_generator.C_out, W_GT_sensor.C_in)
     annotation (Line(points={{-352.8,34},{-346,34}}, color={244,125,35}));
   connect(W_GT_sensor.C_out, sink_power.C_in)
@@ -744,8 +751,6 @@ equation
     annotation (Line(points={{-186,-26},{-242,-26}}, color={95,95,95}));
   connect(P_w_HPSH1_out_sensor.C_out, HPsuperheater2.C_cold_in) annotation (
      Line(points={{-214,8},{-260,8},{-260,-2}}, color={28,108,200}));
-  connect(P_w_HPSH2_out_sensor.C_out, HPST_control_valve.C_in) annotation (Line(
-        points={{-282,58},{-282,148},{-203.25,148}}, color={28,108,200}));
   connect(turbine_P_out_sensor.C_out, HPsuperheater2.C_hot_in)
     annotation (Line(points={{-338,-26},{-302,-26}}, color={95,95,95}));
   connect(deSH_opening_sensor.Opening, deSH_controlValve.Opening)
@@ -771,16 +776,21 @@ equation
     annotation (Line(points={{35,18.1822},{35,33.9}}, color={0,0,127}));
   connect(economiser.C_hot_out, T_flue_gas_sink_sensor.C_in) annotation (Line(
         points={{132,-26.5},{132,-26},{164,-26}},     color={95,95,95}));
-  connect(T_flue_gas_sink_sensor.C_out, P_flue_gas_sink_sensor.C_in)
-    annotation (Line(points={{176,-26},{222,-26},{222,166}}, color={95,95,95}));
-  connect(P_source_air_sensor.C_in, moistAir_to_FlueGases.outlet) annotation (Line(points={{-636,-26},{-652,-26}}, color={95,95,95}));
-  connect(moistAir_to_FlueGases.inlet, source_air.C_out) annotation (Line(points={{-672,-26},{-693,-26}}, color={85,170,255}));
   connect(P_HPST_out_sensor.C_out, T_HPST_out_sensor.C_in) annotation (Line(points={{-102,148},{-96,148}}, color={28,108,200}));
   connect(T_HPST_out_sensor.C_out, Reheater.C_cold_in) annotation (Line(points={{-84,148},{-60,148},{-60,-2}}, color={28,108,200}));
   connect(airCompressor.C_W_in, gasTurbine.C_W_shaft) annotation (Line(
       points={{-496,-15.5},{-496,8},{-382,8},{-382,-10}},
       color={244,125,35},
       smooth=Smooth.Bezier));
+  connect(T_flue_gas_sink_sensor.C_out, P_flue_gas_sink_sensor.C_in) annotation (Line(points={{176,-26},{222,-26},{222,166}},                     color={95,95,95}));
+  connect(HPST_control_valve.C_in, displayer.C_out) annotation (Line(points={{-203.25,148},{-216,148},{-216,148},{-235,148}}, color={28,108,200}));
+  connect(displayer.C_in, P_w_HPSH2_out_sensor.C_out) annotation (Line(points={{-241,148},{-280,148},{-280,82},{-282,82},{-282,58}}, color={28,108,200}));
+  connect(source_fuel.C_out, fuelDisplayer.C_in) annotation (Line(points={{-442,-105},{-442,-95}}, color={213,213,0}));
+  connect(fuelDisplayer.C_out, T_fuel_source_sensor.C_in) annotation (Line(points={{-442,-89},{-442,-80}}, color={213,213,0}));
+  connect(moistAir_to_FlueGases.inlet, moistAirDisplayer.C_out) annotation (Line(points={{-672,-26},{-687,-26}}, color={85,170,255}));
+  connect(moistAirDisplayer.C_in, source_air.C_out) annotation (Line(points={{-693,-26},{-705,-26}}, color={85,170,255}));
+  connect(P_source_air_sensor.C_in, flueGasesDisplayer.C_out) annotation (Line(points={{-636,-26},{-641,-26}}, color={95,95,95}));
+  connect(flueGasesDisplayer.C_in, moistAir_to_FlueGases.outlet) annotation (Line(points={{-647,-26},{-652,-26}}, color={95,95,95}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-720,-120},{260,280}})),
                                                               Diagram(
         coordinateSystem(preserveAspectRatio=false, extent={{-720,-120},{260,280}}),

--- a/MetroscopeModelingLibrary/Partial/Sensors/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/DeltaPressureSensor.mo
@@ -11,7 +11,7 @@ partial model DeltaPressureSensor
   Real DP_mbar(unit="mbar", start=DP_0*Utilities.Constants.Pa_to_mbar); // Pressure difference in mbar
   Real DP_psi(start=DP_0*Utilities.Constants.Pa_to_psiA); // Pressure difference in PSI
 
-  outer parameter Boolean display_output = true "Used to switch ON or OFF output display";
+  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
   parameter String display_unit = "bar" "Specify the display unit"
     annotation(choices(choice="bar", choice="mbar", choice="psi", choice="Pa"));
 

--- a/MetroscopeModelingLibrary/Partial/Sensors/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/DeltaPressureSensor.mo
@@ -7,12 +7,13 @@ partial model DeltaPressureSensor
 
   parameter Utilities.Units.DifferentialPressure DP_0=1e4;
   Utilities.Units.DifferentialPressure DP(start=DP_0, nominal=DP_0);
-  Real DP_bar(unit="bar", start=DP_0*Utilities.Constants.Pa_to_barA);
-                                                              // Pressure difference in bar
-  Real DP_mbar(unit="mbar", start=DP_0*Utilities.Constants.Pa_to_mbar);
-                                                              // Pressure difference in mbar
-  Real DP_psi(start=DP_0*Utilities.Constants.Pa_to_psiA);
-                                                // Pressure difference in PSI
+  Real DP_bar(unit="bar", start=DP_0*Utilities.Constants.Pa_to_barA); // Pressure difference in bar
+  Real DP_mbar(unit="mbar", start=DP_0*Utilities.Constants.Pa_to_mbar); // Pressure difference in mbar
+  Real DP_psi(start=DP_0*Utilities.Constants.Pa_to_psiA); // Pressure difference in PSI
+
+  outer parameter Boolean display_output = true "Used to switch ON or OFF output display";
+  parameter String display_unit = "bar" "Specify the display unit"
+    annotation(choices(choice="bar", choice="mbar", choice="psi", choice="Pa"));
 
   replaceable Partial.Connectors.FluidInlet C_in(redeclare package Medium = Medium) annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   replaceable Partial.Connectors.FluidOutlet C_out(redeclare package Medium = Medium) annotation (Placement(transformation(extent={{90,-10},{110,10}})));
@@ -32,4 +33,14 @@ equation
   DP_bar =DP*Utilities.Constants.Pa_to_barA;
   DP_mbar =DP*Utilities.Constants.Pa_to_mbar;
   DP_psi =DP*Utilities.Constants.Pa_to_psiA;
+
+  annotation (Icon(graphics={Text(
+          extent={{-100,-160},{102,-200}},
+          textColor={0,0,0},
+          textString=if display_output then
+                     if display_unit == "mbar" then DynamicSelect("",String(DP_mbar)+" mbar")
+                     else if display_unit == "psi" then DynamicSelect("",String(DP_psi)+" psi")
+                     else if display_unit == "Pa" then DynamicSelect("",String(DP)+" Pa")
+                     else DynamicSelect("",String(DP_bar)+" bar")
+                     else "")}));
 end DeltaPressureSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/Displayer.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/Displayer.mo
@@ -5,7 +5,7 @@ partial model Displayer
   replaceable package Medium = MetroscopeModelingLibrary.Partial.Media.PartialMedium;
 
   // Initialization parameters
-  parameter Units.PositiveMassFlowRate Q_0=100;
+  parameter Units.PositiveMassFlowRate Q_0 = 100;
   parameter Units.Pressure P_0 = 1e5;
   parameter Units.SpecificEnthalpy h_0 = 5e5;
 

--- a/MetroscopeModelingLibrary/Partial/Sensors/Displayer.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/Displayer.mo
@@ -1,0 +1,46 @@
+within MetroscopeModelingLibrary.Partial.Sensors;
+partial model Displayer
+
+  import MetroscopeModelingLibrary.Utilities.Units;
+  replaceable package Medium = MetroscopeModelingLibrary.Partial.Media.PartialMedium;
+
+  // Initialization parameters
+  parameter Units.PositiveMassFlowRate Q_0=100;
+  parameter Units.Pressure P_0 = 1e5;
+  parameter Units.SpecificEnthalpy h_0 = 5e5;
+
+
+  replaceable BaseClasses.IsoPHFlowModel flow_model annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  replaceable Connectors.FluidInlet C_in(Q(start=Q_0, nominal=Q_0), P(start=P_0, nominal=P_0), redeclare package Medium = Medium) annotation (Placement(transformation(extent={{-40,-10},{-20,10}}), iconTransformation(extent={{-40,-10},{-20,10}})));
+  replaceable Connectors.FluidOutlet C_out(Q(start=-Q_0, nominal=Q_0), P(start=P_0, nominal=P_0), redeclare package Medium = Medium) annotation (Placement(transformation(extent={{20,-10},{40,10}}), iconTransformation(extent={{20,-10},{40,10}})));
+
+equation
+  connect(flow_model.C_in, C_in) annotation (Line(points={{-10,0},{-30,0}}, color={95,95,95}));
+  connect(flow_model.C_out, C_out) annotation (Line(points={{10,0},{30,0}}, color={0,0,0}));
+  annotation (Icon(coordinateSystem(extent={{-100,-100},{100,100}}),
+                   graphics={
+      Text(
+        extent={{-80,60},{80,40}},
+        textColor={0,0,0},
+          textString=DynamicSelect("",String(flow_model.T-273.15)+" degC")),
+      Text(
+        extent={{-80,82},{80,62}},
+        textColor={0,0,0},
+          textString=DynamicSelect("",String(flow_model.P*1e-5)+" barA")),
+      Text(
+        extent={{-80,100},{80,80}},
+        textColor={0,0,0},
+          textString=DynamicSelect("",String(flow_model.Q)+" kg/s")),
+        Line(
+          points={{0,40},{0,0}},
+          color={238,46,47},
+          thickness=1),
+        Line(
+          points={{20,20},{0,0},{-20,20}},
+          color={238,46,47},
+          thickness=1),
+      Text(
+        extent={{-80,120},{80,100}},
+        textColor={0,0,0},
+          textString=DynamicSelect("",String(flow_model.h*1e-6)+" MJ/kg"))}), Diagram(coordinateSystem(extent={{-100,-100},{100,100}})));
+end Displayer;

--- a/MetroscopeModelingLibrary/Partial/Sensors/FlowSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/FlowSensor.mo
@@ -18,10 +18,27 @@ partial model FlowSensor
 
   // Failure modes
   parameter Boolean faulty = false;
+
+  parameter String display_unit = "kg/s" "Specify the display unit"
+    annotation(choices(choice="kg/s", choice="m3/s", choice="l/m", choice="t/h", choice="lb/s", choice="Mlb/h"));
+  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+
 equation
   Qv = Q / Medium.density(state);
   Q_lm = Qv * Constants.m3s_to_lm;
   Q_th = Q * Constants.kgs_to_th;
   Q_lbs = Q * Constants.kgs_to_lbs;
   Q_Mlbh = Q * Constants.kgs_to_Mlbh;
+
+  annotation (Icon(graphics={Text(
+        extent={{-100,-160},{102,-200}},
+        textColor={0,0,0},
+        textString=if display_output then
+                   if display_unit == "m3/s" then DynamicSelect("",String(Qv)+" m3/s")
+                   else if display_unit == "l/m" then DynamicSelect("",String(Q_lm)+" l/m")
+                   else if display_unit == "t/h" then DynamicSelect("",String(Q_th)+" t/h")
+                   else if display_unit == "lb/s" then DynamicSelect("",String(Q_lbs)+" lb/s")
+                   else if display_unit == "Mlb/h" then DynamicSelect("",String(Q_Mlbh)+" Mlb/h")
+                   else DynamicSelect("",String(Q)+" kg/s")
+                   else "")}));
 end FlowSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/PressureSensor.mo
@@ -22,6 +22,10 @@ partial model PressureSensor
   Real P_inHg(nominal = P_0*Constants.Pa_to_inHg, start = P_0*Constants.Pa_to_inHg); // Absolute pressure in inches of mercury
   Real P_mbar(nominal = P_0*Constants.Pa_to_mbar, start = P_0*Constants.Pa_to_mbar, unit="mbar"); // Absolute pressure in milibar
 
+  outer parameter Boolean display_output = true "Used to switch ON or OFF output display";
+  parameter String display_unit = "barA" "Specify the display unit"
+    annotation(choices(choice="barA", choice="barG", choice="mbar", choice="MPaA", choice="kPaA"));
+
 equation
   P_barA = P * Constants.Pa_to_barA;
   P_psiA = P * Constants.Pa_to_psiA;
@@ -35,4 +39,15 @@ equation
 
   P_mbar = P * Constants.Pa_to_mbar;
   P_inHg = P * Constants.Pa_to_inHg;
+
+  annotation (Icon(graphics={Text(
+          extent={{-100,-160},{102,-200}},
+          textColor={0,0,0},
+          textString=if display_output then
+                     if display_unit == "barG" then DynamicSelect("",String(P_barG)+" barG")
+                     else if display_unit == "mbar" then DynamicSelect("",String(P_mbar)+" mbar")
+                     else if display_unit == "MPaA" then DynamicSelect("",String(P_MPaA)+" MPaA")
+                     else if display_unit == "kPaA" then DynamicSelect("",String(P_kPaA)+" kPaA")
+                     else DynamicSelect("",String(P_barA)+" barA")
+                     else "")}));
 end PressureSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/PressureSensor.mo
@@ -22,7 +22,7 @@ partial model PressureSensor
   Real P_inHg(nominal = P_0*Constants.Pa_to_inHg, start = P_0*Constants.Pa_to_inHg); // Absolute pressure in inches of mercury
   Real P_mbar(nominal = P_0*Constants.Pa_to_mbar, start = P_0*Constants.Pa_to_mbar, unit="mbar"); // Absolute pressure in milibar
 
-  outer parameter Boolean display_output = true "Used to switch ON or OFF output display";
+  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
   parameter String display_unit = "barA" "Specify the display unit"
     annotation(choices(choice="barA", choice="barG", choice="mbar", choice="MPaA", choice="kPaA"));
 

--- a/MetroscopeModelingLibrary/Partial/Sensors/TemperatureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/TemperatureSensor.mo
@@ -15,8 +15,22 @@ partial model TemperatureSensor
   Real T_degF(unit="degF",
               start=(T_0 +Constants.T0_degC_in_K) *Constants.degC_to_degF +Constants.T0_degC_in_degF,
               nominal=(T_0 +Constants.T0_degC_in_K) *Constants.degC_to_degF +Constants.T0_degC_in_degF);   // Temperature in degF
+
+  parameter String display_unit = "degC" "Specify the display unit"
+    annotation(choices(choice="degC", choice="K", choice="degF"));
+  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+
 equation
   T =flow_model.T;
   T_degC +Constants.T0_degC_in_K  = T; // Conversion K to Celsius
   T_degF = T_degC*Constants.degC_to_degF +Constants.T0_degC_in_degF;   // Conversion Celsius to Farenheit
+
+  annotation (Icon(graphics={Text(
+        extent={{-100,-160},{102,-200}},
+        textColor={0,0,0},
+        textString=if display_output then
+                   if display_unit == "K" then DynamicSelect("",String(T)+" K")
+                   else if display_unit == "degF" then DynamicSelect("",String(T_degF)+" degF")
+                   else DynamicSelect("",String(T_degC)+" degC")
+                   else "")}));
 end TemperatureSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/package.order
+++ b/MetroscopeModelingLibrary/Partial/Sensors/package.order
@@ -4,3 +4,4 @@ PressureSensor
 FlowSensor
 DeltaPressureSensor
 BaseAbstractSensor
+Displayer

--- a/MetroscopeModelingLibrary/Sensors/Displayer.mo
+++ b/MetroscopeModelingLibrary/Sensors/Displayer.mo
@@ -1,0 +1,78 @@
+within MetroscopeModelingLibrary.Sensors;
+package Displayer
+
+  model WaterDisplayer
+    package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
+
+    extends Partial.Sensors.Displayer(
+      redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Inlet C_in,
+      redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Outlet C_out,
+      redeclare MetroscopeModelingLibrary.WaterSteam.BaseClasses.IsoPHFlowModel flow_model,
+      redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=true));
+
+    annotation (Icon(graphics={Line(
+            points={{-40,0},{42,0}},
+            color={28,108,200},
+            thickness=1)}));
+  end WaterDisplayer;
+
+  model FlueGasesDisplayer
+    package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
+
+    extends Partial.Sensors.Displayer(
+      redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
+      redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
+      redeclare MetroscopeModelingLibrary.FlueGases.BaseClasses.IsoPHFlowModel flow_model,
+      redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=true));
+
+    annotation (Icon(graphics={Line(
+            points={{-40,0},{42,0}},
+            color={95,95,95},
+            thickness=1)}));
+  end FlueGasesDisplayer;
+
+  model FuelDisplayer
+    package FuelMedium = MetroscopeModelingLibrary.Utilities.Media.FuelMedium;
+
+    extends Partial.Sensors.Displayer(
+      redeclare MetroscopeModelingLibrary.Fuel.Connectors.Inlet C_in,
+      redeclare MetroscopeModelingLibrary.Fuel.Connectors.Outlet C_out,
+      redeclare MetroscopeModelingLibrary.Fuel.BaseClasses.IsoPHFlowModel flow_model,
+      redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=true));
+
+    annotation (Icon(graphics={Line(
+            points={{-40,0},{42,0}},
+            color={213,213,0},
+            thickness=1)}));
+  end FuelDisplayer;
+
+  model MoistAirDisplayer
+    package MoistAirMedium = MetroscopeModelingLibrary.Utilities.Media.MoistAirMedium;
+
+    extends Partial.Sensors.Displayer(
+      redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Inlet C_in,
+      redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Outlet C_out,
+      redeclare MetroscopeModelingLibrary.MoistAir.BaseClasses.IsoPHFlowModel flow_model,
+      redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=true));
+
+    annotation (Icon(graphics={Line(
+            points={{-40,0},{42,0}},
+            color={85,170,255},
+            thickness=1)}));
+  end MoistAirDisplayer;
+  annotation (Icon(graphics={
+        Rectangle(
+          lineColor={200,200,200},
+          fillColor={248,248,248},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-100,-100},{100,100}},
+          radius=25.0),
+        Line(
+          points={{0,72},{0,-80}},
+          color={238,46,47},
+          thickness=1),
+        Line(
+          points={{60,-20},{0,-82},{-62,-20}},
+          color={238,46,47},
+          thickness=1)}));
+end Displayer;

--- a/MetroscopeModelingLibrary/Sensors/FlueGases/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/FlueGases/DeltaPressureSensor.mo
@@ -1,11 +1,13 @@
 within MetroscopeModelingLibrary.Sensors.FlueGases;
 model DeltaPressureSensor
   package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
 
   extends Partial.Sensors.DeltaPressureSensor(
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
-    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
+
 end DeltaPressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/FlueGases/FlowSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/FlueGases/FlowSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.FlueGases;
 model FlowSensor
   package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlueGasesSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
 
   extends Partial.Sensors.FlowSensor(
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.FlueGases.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlueGasesSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
+
 end FlowSensor;

--- a/MetroscopeModelingLibrary/Sensors/FlueGases/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/FlueGases/PressureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.FlueGases;
 model PressureSensor
   package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlueGasesSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
 
   extends Partial.Sensors.PressureSensor(
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.FlueGases.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlueGasesSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
+
 end PressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/FlueGases/TemperatureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/FlueGases/TemperatureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.FlueGases;
 model TemperatureSensor
   package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlueGasesSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
 
   extends Partial.Sensors.TemperatureSensor(
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.FlueGases.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FlueGasesMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlueGasesSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
+
 end TemperatureSensor;

--- a/MetroscopeModelingLibrary/Sensors/Fuel/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Fuel/DeltaPressureSensor.mo
@@ -1,11 +1,13 @@
 within MetroscopeModelingLibrary.Sensors.Fuel;
 model DeltaPressureSensor
   package FuelMedium = MetroscopeModelingLibrary.Utilities.Media.FuelMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
 
   extends Partial.Sensors.DeltaPressureSensor(
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Outlet C_out,
-    redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
+
 end DeltaPressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/Fuel/FlowSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Fuel/FlowSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.Fuel;
 model FlowSensor
   package FuelMedium = MetroscopeModelingLibrary.Utilities.Media.FuelMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FuelSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
 
   extends Partial.Sensors.FlowSensor(
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.Fuel.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FuelSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
+
 end FlowSensor;

--- a/MetroscopeModelingLibrary/Sensors/Fuel/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Fuel/PressureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.Fuel;
 model PressureSensor
   package FuelMedium = MetroscopeModelingLibrary.Utilities.Media.FuelMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FuelSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
 
   extends Partial.Sensors.PressureSensor(
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.Fuel.BaseClasses.IsoPHFlowModel flow_model,
     redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=false));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FuelSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
+
 end PressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/Fuel/TemperatureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Fuel/TemperatureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.Fuel;
 model TemperatureSensor
   package FuelMedium = MetroscopeModelingLibrary.Utilities.Media.FuelMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FuelSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
 
   extends Partial.Sensors.TemperatureSensor(
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.Fuel.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.Fuel.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = FuelMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FuelSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
+
 end TemperatureSensor;

--- a/MetroscopeModelingLibrary/Sensors/MoistAir/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/MoistAir/DeltaPressureSensor.mo
@@ -1,11 +1,13 @@
 within MetroscopeModelingLibrary.Sensors.MoistAir;
 model DeltaPressureSensor
   package MoistAirMedium = MetroscopeModelingLibrary.Utilities.Media.MoistAirMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
 
   extends Partial.Sensors.DeltaPressureSensor(
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Outlet C_out,
-    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
+
 end DeltaPressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/MoistAir/FlowSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/MoistAir/FlowSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.MoistAir;
 model FlowSensor
   package MoistAirMedium = MetroscopeModelingLibrary.Utilities.Media.MoistAirMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
 
   extends Partial.Sensors.FlowSensor(
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.MoistAir.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
+
 end FlowSensor;

--- a/MetroscopeModelingLibrary/Sensors/MoistAir/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/MoistAir/PressureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.MoistAir;
 model PressureSensor
   package MoistAirMedium = MetroscopeModelingLibrary.Utilities.Media.MoistAirMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
 
   extends Partial.Sensors.PressureSensor(
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.MoistAir.BaseClasses.IsoPHFlowModel flow_model,
     redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=false));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
+
 end PressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/MoistAir/TemperatureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/MoistAir/TemperatureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.MoistAir;
 model TemperatureSensor
   package MoistAirMedium = MetroscopeModelingLibrary.Utilities.Media.MoistAirMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
 
   extends Partial.Sensors.TemperatureSensor(
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.MoistAir.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
+
 end TemperatureSensor;

--- a/MetroscopeModelingLibrary/Sensors/Outline/OpeningSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Outline/OpeningSensor.mo
@@ -6,6 +6,9 @@ model OpeningSensor
 
   parameter Utilities.Units.Percentage Opening_pc_0(unit="1") = 15;
   Inputs.InputPercentage Opening_pc(unit="1", start=Opening_pc_0, min=0, max=100, nominal=Opening_pc_0); // Opening in percentage
+
+  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+
   Modelica.Blocks.Interfaces.RealOutput Opening(unit="1", min=0, max=1, nominal=Opening_pc_0/100, start=Opening_pc_0/100)
     annotation (Placement(transformation(
         extent={{-27,-27},{27,27}},
@@ -15,4 +18,9 @@ model OpeningSensor
         origin={0,-102})));
 equation
   Opening_pc = Opening * 100;
+  annotation (Icon(graphics={ Text(
+          extent={{-100,200},{100,160}},
+          textColor={0,0,0},
+          textString=if display_output then DynamicSelect("",String(Opening_pc)+" %%")
+          else "")}));
 end OpeningSensor;

--- a/MetroscopeModelingLibrary/Sensors/Power/PowerSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Power/PowerSensor.mo
@@ -8,6 +8,10 @@ model PowerSensor
                   // Power in W
   Real W_MW(min=0, nominal=100, start=100); // Power in MW
 
+  parameter String display_unit = "MW" "Specify the display unit"
+    annotation(choices(choice="MW", choice="W"));
+  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+
   MetroscopeModelingLibrary.Power.Connectors.Inlet C_in annotation (Placement(transformation(extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},{-90,10}})));
   MetroscopeModelingLibrary.Power.Connectors.Outlet C_out annotation (Placement(transformation(extent={{88,-10},{108,10}}), iconTransformation(extent={{88,-10},{108,10}})));
 equation
@@ -17,4 +21,12 @@ equation
   // Measure
   W = C_in.W;
   W_MW = W/1e6;
+
+  annotation (Icon(graphics={Text(
+      extent={{-100,-160},{102,-200}},
+      textColor={0,0,0},
+      textString=if display_output then
+                 if display_unit == "W" then DynamicSelect("",String(W)+" W")
+                 else DynamicSelect("",String(W_MW)+" MW")
+                 else "")}));
 end PowerSensor;

--- a/MetroscopeModelingLibrary/Sensors/WaterSteam/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/WaterSteam/DeltaPressureSensor.mo
@@ -1,11 +1,13 @@
 within MetroscopeModelingLibrary.Sensors.WaterSteam;
 model DeltaPressureSensor
   package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
 
   extends Partial.Sensors.DeltaPressureSensor(
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Outlet C_out,
-    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.OutlineSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.DeltaPressureIcon;
+
 end DeltaPressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/WaterSteam/FlowSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/WaterSteam/FlowSensor.mo
@@ -1,12 +1,13 @@
 within MetroscopeModelingLibrary.Sensors.WaterSteam;
 model FlowSensor
   package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.WaterSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
 
   extends Partial.Sensors.FlowSensor(
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.WaterSteam.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.WaterSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.FlowIcon;
 end FlowSensor;

--- a/MetroscopeModelingLibrary/Sensors/WaterSteam/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/WaterSteam/PressureSensor.mo
@@ -1,12 +1,13 @@
 within MetroscopeModelingLibrary.Sensors.WaterSteam;
 model PressureSensor
   package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.WaterSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
 
   extends Partial.Sensors.PressureSensor(
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.WaterSteam.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=true));
+
+    extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.WaterSensorIcon;
+    extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;
 end PressureSensor;

--- a/MetroscopeModelingLibrary/Sensors/WaterSteam/TemperatureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/WaterSteam/TemperatureSensor.mo
@@ -1,12 +1,14 @@
 within MetroscopeModelingLibrary.Sensors.WaterSteam;
 model TemperatureSensor
   package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.WaterSensorIcon;
-  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
 
   extends Partial.Sensors.TemperatureSensor(
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.WaterSteam.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.WaterSteam.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = WaterSteamMedium) annotation (IconMap(primitivesVisible=true));
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.WaterSensorIcon;
+  extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.TemperatureIcon;
+
 end TemperatureSensor;

--- a/MetroscopeModelingLibrary/Sensors/package.mo
+++ b/MetroscopeModelingLibrary/Sensors/package.mo
@@ -1,4 +1,4 @@
-﻿within MetroscopeModelingLibrary;
+within MetroscopeModelingLibrary;
 package Sensors
 
 annotation (Icon(graphics={
@@ -35,9 +35,8 @@ annotation (Icon(graphics={
           fillColor={64,64,64},
           pattern=LinePattern.None,
           fillPattern=FillPattern.Solid,
-          extent={{-7,-7},{7,7}})}));
-
-annotation(Documentation(info="<html>
+          extent={{-7,-7},{7,7}})}),
+           Documentation(info="<html>
   <p>Licensed by Metroscope under the Modelica License 2 </p>
 <p>Copyright © 2023, Metroscope.</p>
 <p>This Modelica package is free software and the use is completely at your own risk; it can be redistributed and/or modified under the terms of the Modelica License 2. </p>

--- a/MetroscopeModelingLibrary/Sensors/package.order
+++ b/MetroscopeModelingLibrary/Sensors/package.order
@@ -5,3 +5,4 @@ MoistAir
 Power
 Outline
 Abstract
+Displayer


### PR DESCRIPTION
## Goal

Added a feature to display values on sensors.
For each sensor type (T, P, Q and DP), a parameter `display_unit` is added to select the unit to be displayed.
A global parameter `display_output` is `false` by default. To activate it, a parameter should be added in the model where the sensors are used: 

> inner parameter Boolean display_output = true "Used to switch ON or OFF output display";

Moreover, a new component `Displayer` is added for each fluid. When added in a flow line, it will display the enthalpy, flow rate, pressure and temperature. It should be noted that this component is better be deleted after usage. It's a fictive sensor to help during debugging or simulation analysis.

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass.
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
