### PR TITLE
Add Q_reduced in compressor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 ## [Unreleased]
 
 ### ✨ Added <!--Make sure to add a link to the PR and issues related to your change-->
-- Added an IGV component PR[#492](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/492)
+
+- Added Q_reduced in compressor [#498](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/498)
+- Added an IGV component [#492](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/492)
 
 ### 🐛 Fixed <!--Make sure to add a link to the PR and issues related to your change-->
 

--- a/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Machines/AirCompressor.mo
@@ -17,7 +17,8 @@ model AirCompressor
 
   Units.SpecificEnthalpy h_is(start=1e6) "Isentropic compression outlet enthalpy";
   FlueGasesMedium.ThermodynamicState state_is "Isentropic compression outlet thermodynamic state";
-
+  Real Q_reduced "Compressor reduced mass flow";
+    
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage eta_is_decrease(min = 0, max=100) "percentage decrease of eta_is";
@@ -45,7 +46,9 @@ equation
   state_is =  Medium.setState_psX(P_out, Medium.specificEntropy(state_in),Xi);
   h_is = Medium.specificEnthalpy(state_is);
 
-
+  /* Output variable */
+  Q_reduced = Q * sqrt(T_in) / P_in;
+  
   annotation (
     Diagram(coordinateSystem(
         preserveAspectRatio=false,


### PR DESCRIPTION
## Goal

Tiny change, just adding a Q_reduced variable in compressor, to avoid having to recreate it all the time


## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass
- [x] I have checked that my work is compatible with [OpenModelica](https://openmodelica.org/)
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
