### PR TITLE
Unprotect states in HX and updated units, propagated start values parameters in sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 
 ### 💥 Changed <!--Make sure to add a link to the PR and issues related to your change-->
 
+- Unprotect states in HX and updated units, propagated start values parameters in sources [#499](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/499)
+
 ### 🔥 Removed <!--Make sure to add a link to the PR and issues related to your change-->
 
 

--- a/MetroscopeModelingLibrary/FlueGases/Pipes/LoopBreaker.mo
+++ b/MetroscopeModelingLibrary/FlueGases/Pipes/LoopBreaker.mo
@@ -1,0 +1,43 @@
+within MetroscopeModelingLibrary.FlueGases.Pipes;
+model LoopBreaker
+  package FlueGasesMedium = MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium;
+  extends Partial.Pipes.LoopBreaker(
+    redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Inlet C_in,
+    redeclare MetroscopeModelingLibrary.FlueGases.Connectors.Outlet C_out,
+    redeclare package Medium = FlueGasesMedium) annotation(IconMap(primitivesVisible=false));
+  annotation (Icon(graphics={
+        Ellipse(
+          extent={{-36,40},{44,-40}},
+          lineColor={28,108,200},
+          fillColor={170,213,255},
+          fillPattern=FillPattern.Solid,
+          lineThickness=1),
+        Line(
+          points={{44,0},{96,0}},
+          color={28,108,200},
+          thickness=1),
+        Line(
+          points={{-36,0},{-94,0},{-92,0}},
+          color={28,108,200},
+          thickness=1),
+        Line(
+          points={{-20,-4},{-20,10},{20,10}},
+          color={28,108,200},
+          thickness=1),
+        Line(
+          points={{16,14},{20,10},{16,6}},
+          color={28,108,200},
+          thickness=1),
+        Line(
+          points={{-20,-7},{-20,7},{20,7}},
+          color={28,108,200},
+          thickness=1,
+          origin={6,-5},
+          rotation=180),
+        Line(
+          points={{-2,4},{2,0},{-2,-4}},
+          color={28,108,200},
+          thickness=1,
+          origin={-12,-12},
+          rotation=180)}));
+end LoopBreaker;

--- a/MetroscopeModelingLibrary/FlueGases/Pipes/package.order
+++ b/MetroscopeModelingLibrary/FlueGases/Pipes/package.order
@@ -4,3 +4,4 @@ ControlValve
 HeatLoss
 Leak
 PressureCut
+LoopBreaker

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -56,6 +56,14 @@ model FuelHeater
   parameter Units.SpecificEnthalpy h_hot_in_0 = 958265.3;
   parameter Units.SpecificEnthalpy h_hot_out_0 = 5.75e5;
 
+  Units.HeatCapacity Cp_cold_min;
+  Units.HeatCapacity Cp_cold_max;
+  Units.HeatCapacity Cp_hot_min;
+  Units.HeatCapacity Cp_hot_max;
+  FuelMedium.ThermodynamicState state_cold_out; // estimation of the water outlet thermodynamic state
+  WaterSteamMedium.ThermodynamicState state_hot_out; // estimation of the flue gases outlet thermodynamic state
+
+
   Fuel.Connectors.Inlet C_cold_in(Q(start=Q_cold_0), P(start=P_cold_in_0)) annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));
   Fuel.Connectors.Outlet C_cold_out(Q(start=-Q_cold_0), P(start=P_cold_out_0), h_outflow(start= h_cold_out_0)) annotation (Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(extent={{90,-10},{110,10}})));
   WaterSteam.Connectors.Inlet C_hot_in(Q(start=Q_hot_0), P(start=P_hot_in_0)) annotation (Placement(transformation(extent={{30,70},{50,90}}), iconTransformation(extent={{30,70},{50,90}})));
@@ -75,15 +83,6 @@ model FuelHeater
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={40,44})));
-
-
-protected
-  Units.HeatCapacity Cp_cold_min;
-  Units.HeatCapacity Cp_cold_max;
-  Units.HeatCapacity Cp_hot_min;
-  Units.HeatCapacity Cp_hot_max;
-  FuelMedium.ThermodynamicState state_cold_out; // estimation of the water outlet thermodynamic state
-  WaterSteamMedium.ThermodynamicState state_hot_out; // estimation of the flue gases outlet thermodynamic state
 
 
 equation

--- a/MetroscopeModelingLibrary/MultiFluid/Machines/CombustionChamber.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/Machines/CombustionChamber.mo
@@ -13,7 +13,7 @@ model CombustionChamber
   // Performance parameters
   //Inputs.Input
   Inputs.InputFrictionCoefficient Kfr(start=0);
-  Inputs.InputYield eta(start=0.99457); // The value given is found in performance document of GE
+  Inputs.InputReal eta(start=0.99457); // The value given is found in performance document of GE
 
   // Power released by the combustion
   Inputs.InputPower Wth;

--- a/MetroscopeModelingLibrary/Partial/BoundaryConditions/FluidSource.mo
+++ b/MetroscopeModelingLibrary/Partial/BoundaryConditions/FluidSource.mo
@@ -7,19 +7,25 @@ partial model FluidSource
   import MetroscopeModelingLibrary.Utilities.Units;
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
 
-  // Input Quantities
-  Inputs.InputSpecificEnthalpy h_out;
-  Inputs.InputMassFraction Xi_out[Medium.nXi];
-  Inputs.InputPressure P_out;
-  Units.NegativeMassFlowRate Q_out(start=-1e3);
+  // Initialization parameters
+  parameter Units.Pressure P_0 = 1e5;
+  parameter Units.MassFlowRate Q_0 = 1000;
+  parameter Units.SpecificEnthalpy h_0=5e5;
+  parameter Units.Temperature T_0 = 300;
 
-  Units.NegativeVolumeFlowRate Qv_out(start=-1);
+  // Input Quantities
+  Inputs.InputSpecificEnthalpy h_out(start=h_0);
+  Inputs.InputMassFraction Xi_out[Medium.nXi];
+  Inputs.InputPressure P_out(start=P_0);
+  Units.NegativeMassFlowRate Q_out(start=-Q_0);
+
+  Units.NegativeVolumeFlowRate Qv_out(start=-Q_0/1000);
 
   // Computed quantities
-  Units.Temperature T_out;
+  Units.Temperature T_out(start=T_0);
   Medium.ThermodynamicState state_out;
 
-  replaceable MetroscopeModelingLibrary.Partial.Connectors.FluidOutlet C_out(Q(start=-1e3))
+  replaceable MetroscopeModelingLibrary.Partial.Connectors.FluidOutlet C_out(Q(start=-Q_0), P(start=P_0), h_outflow(start=h_0))
     annotation (Placement(transformation(extent={{40,-10},{60,10}}),  iconTransformation(extent={{40,-10},{60,10}})));
 equation
   // Connector

--- a/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
+++ b/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
@@ -55,6 +55,15 @@ partial model WaterFlueGasesMonophasicHX
   parameter Units.SpecificEnthalpy h_hot_in_0 = 6.08e5;
   parameter Units.SpecificEnthalpy h_hot_out_0 = 5.75e5;
 
+
+  // Intermediate variables
+  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_cold_min;
+  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_cold_max;
+  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_hot_min;
+  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_hot_max;
+  MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium.ThermodynamicState state_cold_out; // estimation of the water outlet thermodynamic state
+  MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium.ThermodynamicState state_hot_out; // estimation of the flue gases outlet thermodynamic state
+
   FlueGases.Connectors.Inlet C_hot_in(Q(start=Q_hot_0), P(start=P_hot_in_0)) annotation (Placement(transformation(
           extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));
   FlueGases.Connectors.Outlet C_hot_out(Q(start=-Q_hot_0), P(start=P_hot_out_0), h_outflow(start = h_hot_out_0)) annotation (Placement(transformation(
@@ -82,16 +91,6 @@ partial model WaterFlueGasesMonophasicHX
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={30,42})));
-
-  // Intermediate variables
-protected
-  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_cold_min;
-  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_cold_max;
-  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_hot_min;
-  MetroscopeModelingLibrary.Utilities.Units.HeatCapacity Cp_hot_max;
-  MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium.ThermodynamicState state_cold_out; // estimation of the water outlet thermodynamic state
-  MetroscopeModelingLibrary.Utilities.Media.FlueGasesMedium.ThermodynamicState state_hot_out; // estimation of the flue gases outlet thermodynamic state
-
 equation
   // Failure modes
   if not faulty then

--- a/MetroscopeModelingLibrary/Partial/Machines/Pump.mo
+++ b/MetroscopeModelingLibrary/Partial/Machines/Pump.mo
@@ -14,12 +14,12 @@ partial model Pump
   Inputs.InputHeight a3(start=10) "Constant coef. of the pump characteristics hn = f(vol_flow) (m)";
   Inputs.InputReal b1(start=0) "x^2 coef. of the pump efficiency characteristics rh = f(vol_flow) (s2/m6)";
   Inputs.InputReal b2(start=0) "x coef. of the pump efficiency characteristics rh = f(vol_flow) (s/m3)";
-  Inputs.InputYield b3(start=0.8) "Constant coef. of the pump efficiency characteristics rh = f(vol_flow) (s.u.)";
+  Inputs.InputReal b3(start=0.8) "Constant coef. of the pump efficiency characteristics rh = f(vol_flow) (s.u.)";
 
   Inputs.InputYield rm(start=0.85) "Product of the pump mechanical and electrical efficiencies";
   Inputs.InputYield rh_min(start=0.20) "Minimum efficiency to avoid zero crossings";
 
-  Units.Yield rh "Hydraulic efficiency";
+  Real rh "Hydraulic efficiency";
   Units.Height hn(start=10) "Pump head";
   Units.Fraction R(start=1) "Reduced rotational speed";
 

--- a/MetroscopeModelingLibrary/Partial/Sensors/BaseSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/BaseSensor.mo
@@ -30,7 +30,7 @@ partial model BaseSensor
 
   replaceable Connectors.FluidInlet C_in(Q(start=Q_0, nominal=Q_0), P(start=P_0, nominal=P_0), redeclare package Medium = Medium) annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   replaceable Connectors.FluidOutlet C_out(Q(start=-Q_0, nominal=Q_0), P(start=P_0, nominal=P_0), redeclare package Medium = Medium) annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-  replaceable BaseClasses.IsoPHFlowModel flow_model annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  replaceable BaseClasses.IsoPHFlowModel flow_model(P_0=P_0, Q_0=Q_0, h_0=h_0) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 equation
   if not faulty_flow_rate then
     mass_flow_rate_bias = 0;

--- a/MetroscopeModelingLibrary/Sensors/MoistAir/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/MoistAir/PressureSensor.mo
@@ -6,7 +6,7 @@ model PressureSensor
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Inlet C_in,
     redeclare MetroscopeModelingLibrary.MoistAir.Connectors.Outlet C_out,
     redeclare MetroscopeModelingLibrary.MoistAir.BaseClasses.IsoPHFlowModel flow_model,
-    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=false));
+    redeclare package Medium = MoistAirMedium) annotation (IconMap(primitivesVisible=true));
 
   extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.MoistAirSensorIcon;
   extends MetroscopeModelingLibrary.Utilities.Icons.Sensors.PressureIcon;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reactor.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reactor.mo
@@ -19,7 +19,7 @@ model Reactor
 
   // Failure modes
   parameter Boolean faulty = false;
-  Units.Percentage feed_water_flow_rate_measurement_bias(min = 0, max=20, nominal=1); // Flow rate measurement bias
+  Real feed_water_flow_rate_measurement_bias(nominal=1); // Flow rate measurement bias
 
   Connectors.Inlet feedwater_inlet annotation (Placement(transformation(extent={{20,-10},{40,10}}), iconTransformation(extent={{20,-10},{40,10}})));
   Connectors.Outlet steam_outlet annotation (Placement(transformation(extent={{-10,90},{10,110}}),  iconTransformation(extent={{-10,90},{10,110}})));


### PR DESCRIPTION
## Goal

When I run a model with start values, I get a dozen of warnings like that :
![image](https://github.com/user-attachments/assets/0fc82e0b-08b1-4251-b846-853ec0757aeb)

By making the states regular variables, not protected, it avoids them. And we actually don't need them to be protected, I believe


## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass
- [ ] I have checked that my work is compatible with [OpenModelica](https://openmodelica.org/)
- [ ] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
