### PR TITLE
Solve nominal temperature differences in heat exchanger convergence issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 ### 🐛 Fixed <!--Make sure to add a link to the PR and issues related to your change-->
 
 ### 💥 Changed <!--Make sure to add a link to the PR and issues related to your change-->
+- Breaking change: added a parameter `nominal_DT_default` to set the nominal temperature differences in heat exchanger to the maximum possible temperature difference [#513](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/513)
 
 ### 🔥 Removed 
 
@@ -45,7 +46,6 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 
 
 ## MML - v3.8.0
-
 ### ✨ Added <!--Make sure to add a link to the PR and issues related to your change-->
 - Added sensors name in sensors icons [#473](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/473)
 - Added units for volume, surface tension, dynamic viscosity and thermal conductivity [#474](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/474)

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_direct.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_direct.mo
@@ -133,6 +133,7 @@ model MetroscopiaCCGT_direct
     parameter Real pumpRec_CV_Cvmax = 52.329174; // Recirculation control valve opening
 
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Economiser economiser(
+    nominal_DT_default=false,
       QCp_max_side=Eco_QCp_max_side,
     Q_cold_0=56.89394,
     Q_hot_0=510.45065,
@@ -172,6 +173,7 @@ model MetroscopiaCCGT_direct
         origin={56,34})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Evaporator evaporator(
     x_steam_out(start=1),
+    faulty=false,
     Q_cold_0=47.517586,
     Q_hot_0=510.45065,
     T_cold_in_0=592.94025,
@@ -186,6 +188,7 @@ model MetroscopiaCCGT_direct
     h_0=2691576)
     annotation (Placement(transformation(extent={{-34,28},{-46,40}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater1(
+    nominal_DT_default=false,
       QCp_max_side="unidentified",
     Q_cold_0=47.517586,
     Q_hot_0=510.45065,
@@ -379,6 +382,7 @@ model MetroscopiaCCGT_direct
     T_0=913.15)
     annotation (Placement(transformation(extent={{-370,-7},{-358,5}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater Reheater(
+    nominal_DT_default=false,
       QCp_max_side=ReH_QCp_max_side,
     Q_cold_0=49.734425,
     Q_hot_0=510.45065,
@@ -605,6 +609,7 @@ model MetroscopiaCCGT_direct
     h_0=301935.4)
     annotation (Placement(transformation(extent={{-548,-6},{-536,6}})));
   MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater2(
+    nominal_DT_default=false,
       QCp_max_side=HPSH_QCp_max_side,
     Q_cold_0=49.734425,
     Q_hot_0=510.45065,

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
@@ -134,7 +134,7 @@ model MetroscopiaCCGT_reverse
     output Real Q_pumpRec_out; // Observable: controlled by the economizer input temperature
     output Real turbine_compression_rate; // Observable of interest
 
-  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Economiser economiser(
+  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Economiser economiser(nominal_DT_default=false,
       QCp_max_side=Eco_QCp_max_side)
     annotation (Placement(transformation(extent={{74,-56},{132,3}})));
   MetroscopeModelingLibrary.FlueGases.BoundaryConditions.Sink flue_gas_sink
@@ -152,11 +152,11 @@ model MetroscopiaCCGT_reverse
         extent={{-6,6},{6,-6}},
         rotation=180,
         origin={56,8})));
-  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Evaporator evaporator
+  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Evaporator evaporator(faulty=false)
     annotation (Placement(transformation(extent={{-46,-56},{12,4.5}})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_w_evap_out_sensor(sensor_function="Calibration", causality="SH1_Kfr")
     annotation (Placement(transformation(extent={{-34,2},{-46,14}})));
-  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater1(
+  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater1(nominal_DT_default=false,
       QCp_max_side=HPSH_QCp_max_side)
     annotation (Placement(transformation(extent={{-186,-56},{-126,4}})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH1_out_sensor(sensor_function="Calibration", causality="SH1_Kth")
@@ -245,7 +245,7 @@ model MetroscopiaCCGT_reverse
     annotation (Placement(transformation(extent={{-346,28},{-334,40}})));
   MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor turbine_T_out_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-370,-32},{-358,-20}})));
-  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater Reheater(
+  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater Reheater(nominal_DT_default=false,
       QCp_max_side=ReH_QCp_max_side)
     annotation (Placement(transformation(extent={{-102,-56},{-42,4}})));
   MetroscopeModelingLibrary.WaterSteam.Machines.SteamTurbine LPsteamTurbine annotation (Placement(transformation(extent={{-14,198},{20,230}})));
@@ -347,7 +347,7 @@ model MetroscopiaCCGT_reverse
   MetroscopeModelingLibrary.Sensors.FlueGases.PressureSensor P_filter_out_sensor(
     display_unit="mbar",                                                         sensor_function="Calibration", causality="filter_Kfr")
     annotation (Placement(transformation(extent={{-548,-32},{-536,-20}})));
-  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater2(
+  MetroscopeModelingLibrary.MultiFluid.HeatExchangers.Superheater HPsuperheater2(nominal_DT_default=false,
       QCp_max_side=HPSH_QCp_max_side)
     annotation (Placement(transformation(extent={{-302,-56},{-242,4}})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_w_HPSH2_out_sensor(sensor_function="BC", display_unit="degC")

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -12,6 +12,7 @@ model FuelHeater
 
   // Cp estimation temperatures: estimated temperature differences for both the hot and cold fluids
   parameter Boolean nominal_DT_default = true;
+  Units.Temperature maximum_achiveable_temperature_difference;
   Units.Temperature nominal_cold_side_temperature_rise;
   Units.Temperature nominal_hot_side_temperature_drop;
 
@@ -132,9 +133,10 @@ equation
   // Nominal temperature differences
   // The default temperature rise and drop are equal to the maximum achievable temperature difference
   // Maximum achievable temperature difference for both the hot and cold sides = hot_side.T_in - cold_side.T_in
+  maximum_achiveable_temperature_difference = hot_side.T_in - cold_side.T_in;
   if nominal_DT_default then
-    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in;
-    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in;
+    nominal_cold_side_temperature_rise = maximum_achiveable_temperature_difference;
+    nominal_hot_side_temperature_drop = maximum_achiveable_temperature_difference;
   end if;
 
   Cp_cold_min = FuelMedium.specificHeatCapacityCp(cold_side.state_in); // fuel steam inlet Cp

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -10,10 +10,10 @@ model FuelHeater
   Inputs.InputFrictionCoefficient Kfr_cold;
   Inputs.InputFrictionCoefficient Kfr_hot;
 
-  // Cp estimation temperatures
+  // Cp estimation temperatures: estimated temperature differences for both the hot and cold fluids
   parameter Boolean nominal_DT_default = true;
-  Units.Temperature nominal_cold_side_temperature_rise; // water reference temperature rise based on H&MB diagramm values
-  Units.Temperature nominal_hot_side_temperature_drop; // flue gases reference temperature rise based on H&MB diagramm values
+  Units.Temperature nominal_cold_side_temperature_rise;
+  Units.Temperature nominal_hot_side_temperature_drop;
 
   // Heating
   parameter String QCp_max_side = "undefined";// On fuel heater, QCp_hot may be close to QCp_cold
@@ -130,9 +130,11 @@ equation
   assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
   // Nominal temperature differences
+  // The default temperature rise and drop are equal to the maximum achievable temperature difference
+  // Maximum achievable temperature difference for both the hot and cold sides = hot_side.T_in - cold_side.T_in
   if nominal_DT_default then
-    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
-    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
+    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in;
+    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in;
   end if;
 
   Cp_cold_min = FuelMedium.specificHeatCapacityCp(cold_side.state_in); // fuel steam inlet Cp

--- a/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
+++ b/MetroscopeModelingLibrary/MultiFluid/HeatExchangers/FuelHeater.mo
@@ -9,8 +9,11 @@ model FuelHeater
   // Pressure Losses
   Inputs.InputFrictionCoefficient Kfr_cold;
   Inputs.InputFrictionCoefficient Kfr_hot;
-  Inputs.InputTemperature nominal_cold_side_temperature_rise; // water reference temperature rise based on H&MB diagramm values
-  Inputs.InputTemperature nominal_hot_side_temperature_drop; // flue gases reference temperature rise based on H&MB diagramm values
+
+  // Cp estimation temperatures
+  parameter Boolean nominal_DT_default = true;
+  Units.Temperature nominal_cold_side_temperature_rise; // water reference temperature rise based on H&MB diagramm values
+  Units.Temperature nominal_hot_side_temperature_drop; // flue gases reference temperature rise based on H&MB diagramm values
 
   // Heating
   parameter String QCp_max_side = "undefined";// On fuel heater, QCp_hot may be close to QCp_cold
@@ -125,6 +128,12 @@ equation
   pinch = min(DT_hot_in_side, DT_hot_out_side);
   assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
   assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
+
+  // Nominal temperature differences
+  if nominal_DT_default then
+    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
+    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
+  end if;
 
   Cp_cold_min = FuelMedium.specificHeatCapacityCp(cold_side.state_in); // fuel steam inlet Cp
   state_cold_out = FuelMedium.setState_pTX(cold_side.P_in, cold_side.T_in + nominal_cold_side_temperature_rise,cold_side.Xi);

--- a/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
+++ b/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
@@ -8,8 +8,11 @@ partial model WaterFlueGasesMonophasicHX
   Inputs.InputHeatExchangeCoefficient Kth;
   Inputs.InputFrictionCoefficient Kfr_cold;
   Inputs.InputFrictionCoefficient Kfr_hot;
-  Inputs.InputTemperature nominal_cold_side_temperature_rise; // water reference temperature rise based on H&MB diagramm values
-  Inputs.InputTemperature nominal_hot_side_temperature_drop; // flue gases reference temperature rise based on H&MB diagramm values
+
+  // Cp estimation temperatures
+  parameter Boolean nominal_DT_default = true;
+  Units.Temperature nominal_cold_side_temperature_rise; // water reference temperature rise based on H&MB diagramm values
+  Units.Temperature nominal_hot_side_temperature_drop; // flue gases reference temperature rise based on H&MB diagramm values
 
   parameter String QCp_max_side = "hot";
   // Warning :
@@ -134,6 +137,12 @@ equation
   // For each medium, an average Cp is calculated beteween Cp inlet and an estimation of Cp outlet.
   // The estimation of the Cp outlet is calculated for an outlet temperature based on the nominal temperature rise of the H&MB diagram.
   // For more details about this hypothesis, please refer the Economiser page of the MML documentation.
+
+  // Nominal temperature differences
+  if nominal_DT_default then
+    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
+    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
+  end if;
 
   Cp_cold_min =MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium.specificHeatCapacityCp(cold_side.state_in); // water steam inlet Cp
   state_cold_out =MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium.setState_pTX(

--- a/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
+++ b/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
@@ -11,6 +11,7 @@ partial model WaterFlueGasesMonophasicHX
 
   // Cp estimation temperatures: estimated temperature differences for both the hot and cold fluids
   parameter Boolean nominal_DT_default = true;
+  Units.Temperature maximum_achiveable_temperature_difference;
   Units.Temperature nominal_cold_side_temperature_rise;
   Units.Temperature nominal_hot_side_temperature_drop;
 
@@ -141,6 +142,7 @@ equation
   // Nominal temperature differences
   // The default temperature rise and drop are equal to the maximum achievable temperature difference
   // Maximum achievable temperature difference for both the hot and cold sides = hot_side.T_in - cold_side.T_in
+  maximum_achiveable_temperature_difference = hot_side.T_in - cold_side.T_in;
   if nominal_DT_default then
     nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in;
     nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in;

--- a/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
+++ b/MetroscopeModelingLibrary/Partial/HeatExchangers/WaterFlueGasesMonophasicHX.mo
@@ -9,10 +9,10 @@ partial model WaterFlueGasesMonophasicHX
   Inputs.InputFrictionCoefficient Kfr_cold;
   Inputs.InputFrictionCoefficient Kfr_hot;
 
-  // Cp estimation temperatures
+  // Cp estimation temperatures: estimated temperature differences for both the hot and cold fluids
   parameter Boolean nominal_DT_default = true;
-  Units.Temperature nominal_cold_side_temperature_rise; // water reference temperature rise based on H&MB diagramm values
-  Units.Temperature nominal_hot_side_temperature_drop; // flue gases reference temperature rise based on H&MB diagramm values
+  Units.Temperature nominal_cold_side_temperature_rise;
+  Units.Temperature nominal_hot_side_temperature_drop;
 
   parameter String QCp_max_side = "hot";
   // Warning :
@@ -135,13 +135,15 @@ equation
   assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
 
   // For each medium, an average Cp is calculated beteween Cp inlet and an estimation of Cp outlet.
-  // The estimation of the Cp outlet is calculated for an outlet temperature based on the nominal temperature rise of the H&MB diagram.
-  // For more details about this hypothesis, please refer the Economiser page of the MML documentation.
+  // The estimation of the Cp outlet is calculated for an outlet temperature based on the nominal temperature rise.
+  // For more details about this hypothesis, please refer the WaterFlueGasesMonophasicHX page of the MML documentation.
 
   // Nominal temperature differences
+  // The default temperature rise and drop are equal to the maximum achievable temperature difference
+  // Maximum achievable temperature difference for both the hot and cold sides = hot_side.T_in - cold_side.T_in
   if nominal_DT_default then
-    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
-    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in; // Corresponds to the maximum achievable temperature difference
+    nominal_cold_side_temperature_rise = hot_side.T_in - cold_side.T_in;
+    nominal_hot_side_temperature_drop = hot_side.T_in - cold_side.T_in;
   end if;
 
   Cp_cold_min =MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium.specificHeatCapacityCp(cold_side.state_in); // water steam inlet Cp

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Economiser_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Economiser_direct.mo
@@ -14,12 +14,10 @@ model Economiser_direct
   // Parameters
   parameter String QCp_max_side = "hot";
   parameter Utilities.Units.Area S = 10000;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth = 44.5;
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot = 0.0078;
+  parameter Utilities.Units.HeatExchangeCoefficient Kth = 43.2;
+  parameter Utilities.Units.FrictionCoefficient Kfr_hot = 0.0079;
   parameter Utilities.Units.FrictionCoefficient Kfr_cold = 5840;
 
-  parameter Utilities.Units.Temperature nominal_cold_side_temperature_rise = 43;
-  parameter Utilities.Units.Temperature nominal_hot_side_temperature_drop = 27;
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(
         extent = {{10,-10},{-10,10}},
@@ -31,7 +29,8 @@ model Economiser_direct
         origin={-66,40})));
   MetroscopeModelingLibrary.FlueGases.BoundaryConditions.Source hot_source annotation (Placement(transformation(extent={{-76,-10},{-56,10}})));
   MetroscopeModelingLibrary.FlueGases.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(extent={{36,-10},{56,10}})));
-  MultiFluid.HeatExchangers.Economiser economiser annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+  MultiFluid.HeatExchangers.Economiser economiser(nominal_DT_default=true)
+                                                  annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
 equation
 
   // Boundary Conditions
@@ -50,8 +49,7 @@ equation
   economiser.Kth = Kth;
   economiser.Kfr_hot = Kfr_hot;
   economiser.Kfr_cold = Kfr_cold;
-  economiser.nominal_cold_side_temperature_rise = nominal_cold_side_temperature_rise;
-  economiser.nominal_hot_side_temperature_drop = nominal_hot_side_temperature_drop;
+
 
   connect(economiser.C_hot_out, hot_sink.C_in) annotation (Line(
       points={{0,0},{41,0}},

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Economiser_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Economiser_reverse.mo
@@ -14,8 +14,6 @@ model Economiser_reverse
   // Parameters
   parameter String QCp_max_side = "hot";
   parameter Utilities.Units.Area S = 10000;
-  parameter Utilities.Units.Temperature nominal_cold_side_temperature_rise = 43;
-  parameter Utilities.Units.Temperature nominal_hot_side_temperature_drop = 27;
 
   // Calibrated parameters
   output Utilities.Units.HeatExchangeCoefficient Kth;
@@ -54,8 +52,6 @@ equation
 
   // Parameters
   economiser.S = S;
-  economiser.nominal_cold_side_temperature_rise = nominal_cold_side_temperature_rise;
-  economiser.nominal_hot_side_temperature_drop = nominal_hot_side_temperature_drop;
 
   // Inputs for calibration
   T_cold_out_sensor.T_degC = T_cold_out;
@@ -122,5 +118,6 @@ equation
           pattern = LinePattern.None,
           fillPattern = FillPattern.Solid,
           points = {{-58,-14},{-2,-40},{-58,-74},{-58,-14}})}), Diagram(
-        coordinateSystem(preserveAspectRatio = false, extent={{-100,-100},{100,100}})));
+        coordinateSystem(preserveAspectRatio = false, extent={{-100,-100},{100,100}})),
+    experiment(Interval=0.1, __Dymola_Algorithm="Dassl"));
 end Economiser_reverse;

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_direct.mo
@@ -15,12 +15,10 @@ model FuelHeater_direct
   // Parameters
   parameter String QCp_max_side = "undefined"; // On fuel heater, QCp_hot may be close to QCp_cold
   parameter Units.Area S = 10;
-  parameter Units.Temperature nominal_cold_side_temperature_rise = 20;
-  parameter Units.Temperature nominal_hot_side_temperature_drop = 10;
 
-  parameter Units.HeatExchangeCoefficient Kth = 8740;
+  parameter Units.HeatExchangeCoefficient Kth = 1357;
   parameter Units.FrictionCoefficient Kfr_hot = 0;
-  parameter Units.FrictionCoefficient Kfr_cold = 1;
+  parameter Units.FrictionCoefficient Kfr_cold = 0;
 
   MetroscopeModelingLibrary.Fuel.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-74,-10},{-54,10}})));
   MetroscopeModelingLibrary.Fuel.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{54,-10},{74,10}})));
@@ -45,8 +43,6 @@ equation
   cold_source.Xi_out = {0.92,0.048,0.005,0.002,0.015,0.01};
 
   fuelHeater.S = S;
-  fuelHeater.nominal_cold_side_temperature_rise = nominal_cold_side_temperature_rise;
-  fuelHeater.nominal_hot_side_temperature_drop = nominal_hot_side_temperature_drop;
 
   fuelHeater.Kth = Kth;
   fuelHeater.Kfr_hot = Kfr_hot;

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/FuelHeater_reverse.mo
@@ -13,8 +13,6 @@ model FuelHeater_reverse
   // Parameters
   parameter String QCp_max_side = "undefined"; // On fuel heater, QCp_hot may be close to QCp_cold
   parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.Temperature nominal_cold_side_temperature_rise=20;
-  parameter Utilities.Units.Temperature nominal_hot_side_temperature_drop=10;
 
   // Calibrated parameters
   output Utilities.Units.HeatExchangeCoefficient Kth;
@@ -61,10 +59,8 @@ equation
 
   // Parameters
   fuelHeater.S = S;
-  fuelHeater.nominal_cold_side_temperature_rise = nominal_cold_side_temperature_rise;
-  fuelHeater.nominal_hot_side_temperature_drop = nominal_hot_side_temperature_drop;
 
-    // Inputs for calibration
+  // Inputs for calibration
   T_hot_out_sensor.T_degC = T_hot_out;
   //cold_sink.T_in = T_cold_out +273.15;
   P_cold_out_sensor.P_barA = P_cold_out;

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Superheater_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Superheater_direct.mo
@@ -15,12 +15,10 @@ model Superheater_direct
   parameter String QCp_max_side = "hot";
   parameter Utilities.Units.Area S = 10000;
   parameter Utilities.Units.FrictionCoefficient Kfr_hot = 0;
-  parameter Utilities.Units.Temperature nominal_cold_side_temperature_rise = 105;
-  parameter Utilities.Units.Temperature nominal_hot_side_temperature_drop = 35;
 
   // Calibrated parameters
-  parameter Utilities.Units.HeatExchangeCoefficient Kth = 22.659254;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold = 351.14395;
+  parameter Utilities.Units.HeatExchangeCoefficient Kth = 23.04;
+  parameter Utilities.Units.FrictionCoefficient Kfr_cold = 351.82;
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(
         extent = {{10,-10},{-10,10}},
@@ -47,8 +45,6 @@ equation
   superheater.Kth = Kth;
   superheater.Kfr_hot = Kfr_hot;
   superheater.Kfr_cold = Kfr_cold;
-  superheater.nominal_cold_side_temperature_rise = nominal_cold_side_temperature_rise;
-  superheater.nominal_hot_side_temperature_drop = nominal_hot_side_temperature_drop;
 
   connect(superheater.C_hot_in, hot_source.C_out) annotation (Line(
       points={{-10,0},{-61,0}},

--- a/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Superheater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/Multifluid/HeatExchangers/Superheater_reverse.mo
@@ -14,8 +14,6 @@ model Superheater_reverse
   // Parameters
   parameter String QCp_max_side = "hot";
   parameter Utilities.Units.Area S = 10000;
-  parameter Utilities.Units.Temperature nominal_cold_side_temperature_rise = 105;
-  parameter Utilities.Units.Temperature nominal_hot_side_temperature_drop = 35;
   parameter Utilities.Units.FrictionCoefficient Kfr_hot = 0;
 
   // Calibrated parameters
@@ -51,8 +49,6 @@ equation
 
   // Parameters
   superheater.S = S;
-  superheater.nominal_cold_side_temperature_rise = nominal_cold_side_temperature_rise;
-  superheater.nominal_hot_side_temperature_drop = nominal_hot_side_temperature_drop;
 
   // Observables
   T_cold_out_sensor.T_degC = T_cold_out;


### PR DESCRIPTION
## Goal

Resolves #458 

The goal is to avoid convergence problem related to the values given to the nominal temperature rise and drop in heat exchangers.
A new boolean parameter `nominal_DT_default` is added:
- If `true`, the nominal temperature rise and drop will be equal to the maximum possible temperature difference, `hot_side.T_in - cold_side.T_in`.
- If `false`, customized values should be given.

By default, `nominal_DT_default = true`

⚠️ Breaking change:
You can solve compatibility issue by simply setting `nominal_DT_default` to `false` in all the heat exchangers in your model.
It should be noted, that these temperatures impacts the values of the parameters. If you want to use the default settings after a calibration with customized values, a new calibration should be carried out

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [x] Breaking change (If yes, make sure to point it out in the changelog)
- [ ] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass
- [ ] I have checked that my work is compatible with [OpenModelica](https://openmodelica.org/)
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
