### PR TITLE
Removed all outer parameters for sensors display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
 
 ### 💥 Changed <!--Make sure to add a link to the PR and issues related to your change-->
 - Breaking change: added a parameter `nominal_DT_default` to set the nominal temperature differences in heat exchanger to the maximum possible temperature difference [#513](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/513)
+- Removed outer parameters from sensors. Not breaking, declared inner paramters won't block the model's compilation. [#514](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/514)
 
 ### 🔥 Removed 
 

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_direct.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_direct.mo
@@ -2,9 +2,6 @@ within MetroscopeModelingLibrary.Examples.CCGT.MetroscopiaCCGT;
 model MetroscopiaCCGT_direct
   import MetroscopeModelingLibrary.Utilities.Units;
 
-  inner parameter Boolean show_causality = true "true to show causality, false to hide it";
-  inner parameter Boolean display_output = true "Used to switch ON or OFF output display";
-
   // Boundary conditions
 
     // Air source

--- a/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/MetroscopiaCCGT/MetroscopiaCCGT_reverse.mo
@@ -2,9 +2,6 @@ within MetroscopeModelingLibrary.Examples.CCGT.MetroscopiaCCGT;
 model MetroscopiaCCGT_reverse
   import MetroscopeModelingLibrary.Utilities.Units;
 
-  inner parameter Boolean show_causality = true "true to show causality, false to hide it";
-  inner parameter Boolean display_output = true "Used to switch ON or OFF output display";
-
   // Boundary conditions
 
     // Air source
@@ -265,7 +262,7 @@ model MetroscopiaCCGT_reverse
     annotation (Placement(transformation(extent={{-636,-32},{-624,-20}})));
   MetroscopeModelingLibrary.Sensors.FlueGases.TemperatureSensor T_source_air_sensor(sensor_function="BC")
     annotation (Placement(transformation(extent={{-618,-32},{-606,-20}})));
-  MetroscopeModelingLibrary.Sensors.FlueGases.FlowSensor Q_source_air_sensor(sensor_function="BC")
+  MetroscopeModelingLibrary.Sensors.FlueGases.FlowSensor Q_source_air_sensor(sensor_function="BC", display_output=true)
     annotation (Placement(transformation(extent={{-600,-32},{-588,-20}})));
   MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_circulating_water_in_sensor(sensor_function="BC")
     annotation (Placement(transformation(

--- a/MetroscopeModelingLibrary/Examples/CCGT/airCompressor_with_fogging_direct.mo
+++ b/MetroscopeModelingLibrary/Examples/CCGT/airCompressor_with_fogging_direct.mo
@@ -5,9 +5,6 @@ model airCompressor_with_fogging_direct
 
   package RefMoistAirMedium = MetroscopeModelingLibrary.Utilities.Media.RefMoistAirMedium;
 
-  inner parameter Boolean show_causality = true "true to show causality, false to hide it";
-  inner parameter Boolean display_output = true "Used to switch ON or OFF output display";
-
   // Boundary conditinos
   input Real source_P(start=1) "bar";
   input Units.Temperature source_T(start=20) "degC";

--- a/MetroscopeModelingLibrary/Examples/Nuclear/MetroscopiaNPP/MetroscopiaNPP_reverse.mo
+++ b/MetroscopeModelingLibrary/Examples/Nuclear/MetroscopiaNPP/MetroscopiaNPP_reverse.mo
@@ -1,9 +1,6 @@
 within MetroscopeModelingLibrary.Examples.Nuclear.MetroscopiaNPP;
 model MetroscopiaNPP_reverse
 
-  inner parameter Boolean show_causality = true "true to show causality, false to hide it";
-  inner parameter Boolean display_output = true "Used to switch ON or OFF output display";
-
   // Boundary Conditions
 
     input Real P_steam(start = 50, unit="bar", min=0, nominal=50) "barA"; // Steam generator steam pressure

--- a/MetroscopeModelingLibrary/Partial/Sensors/BaseAbstractSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/BaseAbstractSensor.mo
@@ -6,7 +6,6 @@ model BaseAbstractSensor
   parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
     annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
   parameter String causality = "" "Specify which parameter is calibrated by this sensor";
-  outer parameter Boolean show_causality = true "Used to show or not the causality";
 
   WaterSteam.Connectors.Inlet C_in annotation (Placement(transformation(extent={{-30,-150},{-10,-130}}), iconTransformation(extent={{-30,-150},{-10,-130}})));
   WaterSteam.Connectors.Outlet C_out annotation (Placement(transformation(extent={{10,-150},{30,-130}}), iconTransformation(extent={{10,-150},{30,-130}})));
@@ -25,13 +24,13 @@ model BaseAbstractSensor
       Text(
         extent={{-100,200},{100,160}},
         textColor={107,175,17},
-        textString=if show_causality then "%causality" else ""),
+        textString=if causality <> "" then "%causality" else ""),
       Line(
         points={{100,0},{140,0},{140,180},{100,180}},
         color={107,175,17},
-        arrow=if causality == "" or show_causality == false then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
+        arrow=if causality == "" then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
         thickness=0.5,
-        pattern=if causality == "" or show_causality == false then LinePattern.None else LinePattern.Solid,
+        pattern=if causality == "" then LinePattern.None else LinePattern.Solid,
         smooth=Smooth.Bezier)}));
 
 end BaseAbstractSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/BaseSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/BaseSensor.mo
@@ -25,7 +25,6 @@ partial model BaseSensor
   parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
     annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
   parameter String causality = "" "Specify which parameter is calibrated by this sensor";
-  outer parameter Boolean show_causality = true "Used to show or not the causality";
 
   replaceable Connectors.FluidInlet C_in(Q(start=Q_0, nominal=Q_0), P(start=P_0, nominal=P_0), redeclare package Medium = Medium) annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   replaceable Connectors.FluidOutlet C_out(Q(start=-Q_0, nominal=Q_0), P(start=P_0, nominal=P_0), redeclare package Medium = Medium) annotation (Placement(transformation(extent={{90,-10},{110,10}})));
@@ -60,12 +59,12 @@ equation
       Text(
         extent={{-100,-120},{100,-160}},
         textColor={107,175,17},
-        textString=if show_causality then "%causality" else ""),
+        textString=if causality <> "" then "%causality" else ""),
       Line(
         points={{100,-60},{140,-60},{140,-140},{100,-140}},
         color={107,175,17},
-        arrow=if causality == "" or show_causality == false then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
+        arrow=if causality == "" then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
         thickness=0.5,
-        pattern=if causality == "" or show_causality == false then LinePattern.None else LinePattern.Solid,
+        pattern=if causality == "" then LinePattern.None else LinePattern.Solid,
         smooth=Smooth.Bezier)}));
 end BaseSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/DeltaPressureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/DeltaPressureSensor.mo
@@ -16,8 +16,7 @@ partial model DeltaPressureSensor
   parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
     annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
   parameter String causality = "" "Specify which parameter is calibrated by this sensor";
-  outer parameter Boolean show_causality = true "Used to show or not the causality";
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
   parameter String display_unit = "bar" "Specify the display unit"
     annotation(choices(choice="bar", choice="mbar", choice="psi", choice="Pa"));
 
@@ -63,12 +62,12 @@ equation
           Text(
             extent={{-100,-120},{100,-160}},
             textColor={107,175,17},
-            textString=if show_causality then "%causality" else ""),
+            textString=if causality <> "" then "%causality" else ""),
           Line(
             points={{100,-60},{140,-60},{140,-140},{100,-140}},
             color={107,175,17},
-            arrow=if causality == "" or show_causality == false then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
+            arrow=if causality == "" then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
             thickness=0.5,
-            pattern=if causality == "" or show_causality == false then LinePattern.None else LinePattern.Solid,
+            pattern=if causality == "" then LinePattern.None else LinePattern.Solid,
             smooth=Smooth.Bezier)}));
 end DeltaPressureSensor;

--- a/MetroscopeModelingLibrary/Partial/Sensors/FlowSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/FlowSensor.mo
@@ -23,7 +23,7 @@ partial model FlowSensor
 
   parameter String display_unit = "kg/s" "Specify the display unit"
     annotation(choices(choice="kg/s", choice="m3/s", choice="l/m", choice="t/h", choice="lb/s", choice="Mlb/h"));
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
 equation
   Qv = Q / Medium.density(state);

--- a/MetroscopeModelingLibrary/Partial/Sensors/PressureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/PressureSensor.mo
@@ -23,7 +23,7 @@ partial model PressureSensor
   Real P_inH2O(nominal = P_0*Constants.Pa_to_inH2O, start = P_0*Constants.Pa_to_inH2O); // Absolute pressure in inches of H2O
   Real P_mbar(nominal = P_0*Constants.Pa_to_mbar, start = P_0*Constants.Pa_to_mbar, unit="mbar"); // Absolute pressure in milibar
 
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
   parameter String display_unit = "barA" "Specify the display unit"
     annotation(choices(choice="barA", choice="barG", choice="mbar", choice="MPaA", choice="kPaA"));
 

--- a/MetroscopeModelingLibrary/Partial/Sensors/TemperatureSensor.mo
+++ b/MetroscopeModelingLibrary/Partial/Sensors/TemperatureSensor.mo
@@ -18,7 +18,7 @@ partial model TemperatureSensor
 
   parameter String display_unit = "degC" "Specify the display unit"
     annotation(choices(choice="degC", choice="K", choice="degF"));
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
 equation
   T =flow_model.T;

--- a/MetroscopeModelingLibrary/Sensors/MoistAir/RelativeHumiditySensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/MoistAir/RelativeHumiditySensor.mo
@@ -17,7 +17,7 @@ model RelativeHumiditySensor
   Real relative_humidity_pc(start=relative_humidity_0*100, min=0, max=100);
 
   // Display
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
 equation
   flow_model.Xi[1] = MoistAirMedium.massFraction_pTphi(P, flow_model.T_in, relative_humidity);

--- a/MetroscopeModelingLibrary/Sensors/Outline/OpeningSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Outline/OpeningSensor.mo
@@ -10,8 +10,7 @@ model OpeningSensor
   parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
     annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
   parameter String causality = "" "Specify which parameter is calibrated by this sensor";
-  outer parameter Boolean show_causality = true "Used to show or not the causality";
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
   Modelica.Blocks.Interfaces.RealOutput Opening(unit="1", min=0, max=1, nominal=Opening_pc_0/100, start=Opening_pc_0/100)
     annotation (Placement(transformation(
@@ -40,13 +39,13 @@ equation
       Text(
         extent={{-100,-120},{100,-160}},
         textColor={107,175,17},
-        textString=if show_causality then "%causality" else ""),
+        textString=if causality <> "" then "%causality" else ""),
       Line(
         points={{100,-60},{140,-60},{140,-140},{100,-140}},
         color={107,175,17},
-        arrow=if causality == "" or show_causality == false then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
+        arrow=if causality == "" then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
         thickness=0.5,
-        pattern=if causality == "" or show_causality == false then LinePattern.None else LinePattern.Solid,
+        pattern=if causality == "" then LinePattern.None else LinePattern.Solid,
         smooth=Smooth.Bezier),
       Ellipse(
           extent={{-100,100},{100,-98}},

--- a/MetroscopeModelingLibrary/Sensors/Power/PowerSensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/Power/PowerSensor.mo
@@ -11,10 +11,9 @@ model PowerSensor
   parameter String sensor_function = "Unidentified" "Specify if the sensor is a BC or used for calibration"
     annotation(choices(choice="Unidentified" "No specific function", choice="BC" "Boundary condition", choice="Calibration" "Used for calibration"));
   parameter String causality = "" "Specify which parameter is calibrated by this sensor";
-  outer parameter Boolean show_causality = true "Used to show or not the causality";
   parameter String display_unit = "MW" "Specify the display unit"
     annotation(choices(choice="MW", choice="W"));
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
   MetroscopeModelingLibrary.Power.Connectors.Inlet C_in annotation (Placement(transformation(extent={{-110,-10},{-90,10}}), iconTransformation(extent={{-110,-10},{-90,10}})));
   MetroscopeModelingLibrary.Power.Connectors.Outlet C_out annotation (Placement(transformation(extent={{88,-10},{108,10}}), iconTransformation(extent={{88,-10},{108,10}})));
@@ -46,13 +45,13 @@ equation
       Text(
         extent={{-100,-120},{100,-160}},
         textColor={107,175,17},
-        textString=if show_causality then "%causality" else ""),
+        textString=if causality <> "" then "%causality" else ""),
       Line(
         points={{100,-60},{140,-60},{140,-140},{100,-140}},
         color={107,175,17},
-        arrow=if causality == "" or show_causality == false then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
+        arrow=if causality == "" then {Arrow.None,Arrow.None} else {Arrow.None,Arrow.Filled},
         thickness=0.5,
-        pattern=if causality == "" or show_causality == false then LinePattern.None else LinePattern.Solid,
+        pattern=if causality == "" then LinePattern.None else LinePattern.Solid,
         smooth=Smooth.Bezier),
         Ellipse(
           extent={{-100,100},{100,-100}},

--- a/MetroscopeModelingLibrary/Sensors/RefMoistAir/RelativeHumiditySensor.mo
+++ b/MetroscopeModelingLibrary/Sensors/RefMoistAir/RelativeHumiditySensor.mo
@@ -19,7 +19,7 @@ model RelativeHumiditySensor
   parameter Real k_mair = RefMoistAirMedium.k_mair;
 
   // Display
-  outer parameter Boolean display_output = false "Used to switch ON or OFF output display";
+  parameter Boolean display_output = true "Used to switch ON or OFF output display";
 
 equation
   pds = RefMoistAirMedium.Utilities.pds_pT(P, flow_model.T_in);


### PR DESCRIPTION
## Goal

The goal is to solve compatibility issue with Dymola with version 2021x and older, and OpenModelica. These versions doesn't support default values for outer parameters, causing an error when inner parameters are not defined, an in most of our tests and examples.

In this example we removed both outer parameters `show_causality` and `display_output`:
- `show_causality`: If nothing is written in the `causality` parameter, the causality won't be shown. As soon as this parameter is filled, the arrow and the causality appear.
- `display_output`: This is transformed into an ordinary parameter set to `true` by default. To turn of this display (which should not be a common need), this parameter should be turned off, sensor by sensor. 

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [x] Non-Breaking change

## Checklist

- [x] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x] I have performed a self-review of my own code
- [x] I have checked that all existing tests pass
- [ ] I have checked that my work is compatible with [OpenModelica](https://openmodelica.org/)
- [x] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
