### PR TITLE
Modified heat exchangers and steam dryer with tests

### DIFF
--- a/MetroscopeModelingLibrary/Power/HeatExchange/NTUHeatExchange.mo
+++ b/MetroscopeModelingLibrary/Power/HeatExchange/NTUHeatExchange.mo
@@ -32,6 +32,8 @@ model NTUHeatExchange
   Inputs.InputHeatCapacity Cp_cold(start=Cp_cold_0) "Cold fluid specific heat capacity";
   Inputs.InputTemperature T_hot_in(start=T_hot_in_0) "Temperature, hot side, at the inlet";
   Inputs.InputTemperature T_cold_in(start=T_cold_in_0) "Temperature, cold side, at the inlet";
+//   Inputs.InputTemperature T_hot_out(start=T_hot_in_0) "Temperature, hot side, at the inlet";
+//   Inputs.InputTemperature T_cold_out(start=T_cold_in_0) "Temperature, cold side, at the inlet";
 
   // Exchange parameters
   Real QCpMIN(unit="W/K", start=QCpMIN_0);
@@ -40,6 +42,8 @@ model NTUHeatExchange
   Units.Fraction Cr(start=Cr_0);
   Units.Fraction epsilon(start=epsilon_0);
   Units.Power W_max(start=W_max_0);
+  Real epsilon_max(start = 0.7);
+  //Real epsilon_req( start = 0.7);
 
   // When the QCp_max_side is "hot", the initial parameters may be in the opposite order, however, no impact on the simulations
   parameter Real QCpMIN_0(unit="W/K") = if QCp_max_side == "hot" then Q_cold_0 * Cp_cold_0 elseif QCp_max_side == "cold" then Q_hot_0 * Cp_hot_0 else min(Q_cold_0 * Cp_cold_0,Q_hot_0 * Cp_hot_0);
@@ -56,6 +60,7 @@ equation
   W = epsilon*W_max;
   NTU = Kth*S/QCpMIN;
   Cr = QCpMIN/QCpMAX;
+  //epsilon_req = W/QCpMIN*(T_hot_in - T_cold_in);
 
   if config == "shell_and_tubes_two_passes" then
 
@@ -76,6 +81,8 @@ equation
     assert(QCpMIN < QCpMAX, "QCPMIN is higher than QCpMAX", AssertionLevel.error);
 
     epsilon = 2*1/( 1 + Cr + sqrt(1+Cr^2)* (1+exp(-NTU*(1+Cr^2)^0.5))/(1-exp(-NTU*(1+Cr^2)^0.5)));
+    epsilon_max = 2*1/( 1 + Cr + sqrt(1+Cr^2));
+    assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot_out) too low/too negative, or NTU too high",AssertionLevel.warning);
 
   elseif config == "monophasic_cross_current" then
 
@@ -93,12 +100,19 @@ equation
         QCpMIN = Q_cold*Cp_cold;
         assert(QCpMIN < QCpMAX, "QCPMIN is higher than QCpMAX", AssertionLevel.error);
         epsilon =  (1 - exp(-Cr*(1 - exp(-NTU))))/Cr;
+
+        epsilon_max = (1 - exp(-Cr))/Cr;
+        assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration.(T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
       elseif QCp_max_side == "cold" then
         // QCpMAX is associated to the unmixed fluid
         QCpMIN = Q_hot*Cp_hot;
         QCpMAX = Q_cold*Cp_cold;
         assert(QCpMIN < QCpMAX, "QCPMIN is higher than QCpMAX", AssertionLevel.error);
         epsilon =  1 - exp(-(1 - exp(-Cr*NTU))/Cr);
+        epsilon_max = 1 - exp(-1/Cr);
+        assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration.(T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
       else
         /* If QCpMAX is not predefined
            Identify QCpMAX
@@ -108,12 +122,18 @@ equation
           QCpMAX = Q_cold*Cp_cold;
           // QCpMAX is associated to the unmixed fluid
           epsilon =  1 - exp(-(1 - exp(-Cr*NTU))/Cr);
+          epsilon_max = 1 - exp(-1/Cr);
+        assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration.(T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
         else
           // QCpMAX is associated to the hot fluid
           QCpMAX = Q_hot*Cp_hot;
           QCpMIN = Q_cold*Cp_cold;
           // QCpMAX is associated to the mixed fluid
           epsilon =  (1 - exp(-Cr*(1 - exp(-NTU))))/Cr;
+          epsilon_max = (1 - exp(-Cr))/Cr;
+          assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
         end if;
       end if;
 
@@ -125,12 +145,18 @@ equation
         QCpMIN = Q_cold*Cp_cold;
         assert(QCpMIN < QCpMAX, "QCPMIN is higher than QCpMAX", AssertionLevel.error);
         epsilon =  1 - exp(-(1 - exp(-Cr*NTU))/Cr);
+        epsilon_max = 1 - exp(-1/Cr);
+        assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
       elseif QCp_max_side == "cold" then
         // QCpMAX is associated to the mixed fluid
         QCpMIN = Q_hot*Cp_hot;
         QCpMAX = Q_cold*Cp_cold;
         assert(QCpMIN < QCpMAX, "QCPMIN is higher than QCpMAX", AssertionLevel.error);
         epsilon =  (1 - exp(-Cr*(1 - exp(-NTU))))/Cr;
+        epsilon_max = (1 - exp(-Cr))/Cr;
+        assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
       else
         /* If QCpMAX is not predefined
            Identify QCpMAX
@@ -140,12 +166,18 @@ equation
           QCpMAX = Q_cold*Cp_cold;
           // QCpMAX is associated to the mixed fluid
           epsilon =  (1 - exp(-Cr*(1 - exp(-NTU))))/Cr;
+         epsilon_max = (1 - exp(-Cr))/Cr;
+        assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
         else
           // QCpMAX is associated to the hot fluid
           QCpMAX = Q_hot*Cp_hot;
           QCpMIN = Q_cold*Cp_cold;
           // QCpMAX is associated to the unmixed fluid
           epsilon =  1 - exp(-(1 - exp(-Cr*NTU))/Cr);
+          epsilon_max = 1 - exp(-1/Cr);
+          assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration.(T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
+
         end if;
       end if;
     end if;
@@ -167,6 +199,8 @@ equation
     assert(QCpMIN < QCpMAX, "QCPMIN is higher than QCpMAX", AssertionLevel.error);
 
     epsilon = (1-exp(-NTU*(1-Cr)))/(1-Cr*exp(-NTU*(1-Cr)));
+    epsilon_max = 1;
+    assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
 
     elseif config == "evaporator" then
 
@@ -174,6 +208,8 @@ equation
       QCpMIN = Q_hot*Cp_hot;
 
       epsilon = 1 - exp(-NTU);
+      epsilon_max = 1;
+      assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
 
     elseif config == "condenser" then
 
@@ -181,12 +217,15 @@ equation
       QCpMIN = Q_cold*Cp_cold;
 
       epsilon = 1 - exp(-NTU);
+      epsilon_max = 1;
+      assert(epsilon/epsilon_max < 0.98,"Effectiveness is above 98% of epsilon_max for this configuration. (T_cold_out - T_hot__out) too low/too negative, or NTU too high",AssertionLevel.warning);
 
   else // Added this forbidden case to simplify model checking, but it is anyway overriden by assert below
     QCpMAX = 0;
     QCpMIN = 0;
 
     epsilon = 0;
+    epsilon_max = 0;
   end if;
 
   assert(config == "evaporator" or config == "condenser" or config=="shell_and_tubes_two_passes" or config=="monophasic_cross_current" or config=="monophasic_counter_current", "config parameter of NTUHeatExchange should be one of 'shell_and_tubes_two_passes', 'condenser', 'evaporator', 'monophasic_cross_current', or 'monophasic_counter_current'", AssertionLevel.error);
@@ -219,5 +258,10 @@ equation
           lineColor={238,46,47},
           fillColor={238,46,47},
           fillPattern=FillPattern.Solid)}),                      Diagram(
-        coordinateSystem(preserveAspectRatio=false)));
+        coordinateSystem(preserveAspectRatio=false)),
+    experiment(
+      StopTime=20,
+      __Dymola_NumberOfIntervals=50,
+      __Dymola_fixedstepsize=0.01,
+      __Dymola_Algorithm="Euler"));
 end NTUHeatExchange;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_direct.mo
@@ -7,49 +7,149 @@ model Condenser_direct
   input Utilities.Units.MassFlowRate Q_turbine(start=150) "kg/s";
   input Utilities.Units.SpecificEnthalpy h_turbine(start=1500e3);
 
-  input Real P_cold_source(start=5, min=0, nominal=10) "barA";
-  input Real T_cold_source(start = 15, min = 0, nominal = 50) "degC";
+    // Specifications, if "input_specs" is set to true
+  input Real hotwell_level( start = 1);
 
-    // Parameters
-  parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth=50000;
-  parameter Utilities.Units.Height water_height=2;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=1;
-  parameter Utilities.Units.VolumeFlowRate Qv_cold=3.82;
-  parameter Utilities.Units.Pressure P_offset=0;
-  parameter Real C_incond = 0;
-
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cooling_source annotation (Placement(transformation(extent={{-56,-10},{-36,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{36,-10},{56,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source turbine_outlet annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,46})));
+        origin={0,78})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink condensate_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-46})));
-  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser annotation (Placement(transformation(extent={{-10,-8},{10,10}})));
+        origin={0,-58})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cooling_source annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=0,
+        origin={-86,0})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{74,-10},{94,10}})));
+  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser( input_specs = true)
+    annotation (Placement(transformation(extent={{-10,-8},{10,10}})));
+  Sensors_Control.WaterSteam.TemperatureSensor Circ_Water_Outlet_Temp_sensor(
+    sensor_function="Calibration",
+    causality="Qv cold",
+    T_start=28.4,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Sensors_Control.WaterSteam.PressureSensor Circ_Water_Outlet_Press_sensor(
+    sensor_function="Calibration",
+    causality="Kfr cold",
+    P_start=1,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{52,-10},{72,10}})));
+  Sensors_Control.WaterSteam.PressureSensor Cond_Pressure_sensor(
+    sensor_function="Calibration",
+    causality="Kth",
+    P_start=0.19,
+    signal_unit="barA",
+    display_unit="barA") annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,48})));
+  Sensors_Control.WaterSteam.TemperatureSensor Circ_Water_Inlet_Temp_sensor(
+    sensor_function="BC",
+    T_start=15,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+  Sensors_Control.WaterSteam.PressureSensor Circ_Water_Inlet_Press_sensor(
+    sensor_function="BC",
+    P_start=1.1,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+  Utilities.Interfaces.BoundaryCondition Circ_Water_Inlet_Temp annotation (
+      Placement(transformation(extent={{-64,18},{-56,26}}), iconTransformation(
+          extent={{-268,-24},{-228,16}})));
+  Utilities.Interfaces.BoundaryCondition Circ_Water_Inlet_Press
+                                                               annotation (
+      Placement(transformation(extent={{-34,18},{-26,26}}), iconTransformation(
+          extent={{-268,-24},{-228,16}})));
+  Utilities.Interfaces.RealOutput Kth annotation (Placement(transformation(
+          extent={{-10,18},{-2,26}}), iconTransformation(extent={{-134,-16},{-114,
+            6}})));
+  Utilities.Interfaces.RealOutput Qv_cold_in annotation (Placement(
+        transformation(extent={{-24,28},{-16,36}}), iconTransformation(extent={{
+            -134,-16},{-114,6}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-26,-28},{-18,-20}}), iconTransformation(extent={{-134,-16},{
+            -114,6}})));
+  Sensors_Control.WaterSteam.TemperatureSensor Condensate_Temp_sensor
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,-32})));
+  Utilities.Interfaces.RealOutput Condensate_Temp annotation (Placement(
+        transformation(extent={{26,-36},{34,-28}}), iconTransformation(extent={{
+            -194,-30},{-174,-10}})));
+  Utilities.Interfaces.RealExpression C_incond(y=0)
+    annotation (Placement(transformation(extent={{-2,16},{18,36}})));
+  Utilities.Interfaces.RealOutput Cond_Pressure annotation (Placement(
+        transformation(extent={{18,44},{26,52}}), iconTransformation(extent={{-194,
+            -30},{-174,-10}})));
+  Utilities.Interfaces.RealOutput Circ_Water_Outlet_Temp annotation (Placement(
+        transformation(extent={{26,20},{34,28}}), iconTransformation(extent={{-194,
+            -30},{-174,-10}})));
+  Utilities.Interfaces.RealOutput Circ_Water_Outlet_Press annotation (Placement(
+        transformation(extent={{54,26},{62,34}}), iconTransformation(extent={{-194,
+            -30},{-174,-10}})));
 equation
 
+  // Boundary Conditions
   turbine_outlet.h_out = h_turbine;
   turbine_outlet.Q_out = -Q_turbine;
 
-  cooling_source.P_out = P_cold_source*1e5;
-  cooling_source.T_out = 273.15 + T_cold_source;
+  // Calibrated parameters
+  Qv_cold_in = 3.4;
+  Kfr_cold = 0.89;
+  Kth = 102;
 
-  condenser.S = S;
-  condenser.Kth = Kth;
-  condenser.water_height = water_height;
-  condenser.Kfr_cold = Kfr_cold;
-  condenser.Qv_cold_in = Qv_cold;
-  condenser.P_offset = P_offset;
-  condenser.C_incond = C_incond;
+  // Specifications, if "input_specs" is set to true
+  condenser.water_height = hotwell_level;
+  condenser.S = 50000;
 
-  connect(turbine_outlet.C_out, condenser.C_hot_in) annotation (Line(points={{-8.88178e-16,41},{-8.88178e-16,25.6},{0,25.6},{0,10.2}}, color={28,108,200}));
-  connect(cooling_source.C_out, condenser.C_cold_in) annotation (Line(points={{-41,0},{-10,0}}, color={28,108,200}));
-  connect(cooling_sink.C_in, condenser.C_cold_out) annotation (Line(points={{41,0},{9.8,0}}, color={28,108,200}));
-  connect(condensate_sink.C_in, condenser.C_hot_out) annotation (Line(points={{8.88178e-16,-41},{8.88178e-16,-24.5},{0,-24.5},{0,-8}}, color={28,108,200}));
+  connect(condenser.C_cold_out, Circ_Water_Outlet_Temp_sensor.C_in)
+    annotation (Line(points={{9.8,0},{22,0}}, color={28,108,200}));
+  connect(Circ_Water_Outlet_Temp_sensor.C_out, Circ_Water_Outlet_Press_sensor.C_in)
+    annotation (Line(points={{42,0},{52,0}}, color={28,108,200}));
+  connect(cooling_sink.C_in, Circ_Water_Outlet_Press_sensor.C_out)
+    annotation (Line(points={{79,0},{72,0}}, color={28,108,200}));
+  connect(Cond_Pressure_sensor.C_in, turbine_outlet.C_out)
+    annotation (Line(points={{0,58},{0,73}}, color={28,108,200}));
+  connect(Cond_Pressure_sensor.C_out, condenser.C_hot_in)
+    annotation (Line(points={{0,38},{0,10.2}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Temp_sensor.C_in, cooling_source.C_out)
+    annotation (Line(points={{-70,0},{-81,0}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Press_sensor.C_in, Circ_Water_Inlet_Temp_sensor.C_out)
+    annotation (Line(points={{-40,0},{-50,0}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Press_sensor.C_out, condenser.C_cold_in)
+    annotation (Line(points={{-20,0},{-10,0}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Temp_sensor.T_sensor, Circ_Water_Inlet_Temp)
+    annotation (Line(points={{-60,10},{-60,22}}, color={0,0,127}));
+  connect(Circ_Water_Inlet_Press_sensor.P_sensor, Circ_Water_Inlet_Press)
+    annotation (Line(points={{-30,10},{-30,22}}, color={0,0,127}));
+  connect(condenser.Kth, Kth)
+    annotation (Line(points={{-6.4,11},{-6,11},{-6,22}}, color={0,0,127}));
+  connect(condenser.Qv_cold_in, Qv_cold_in) annotation (Line(points={{-11,8},{-16,
+          8},{-16,24},{-20,24},{-20,32}}, color={0,0,127}));
+  connect(Kfr_cold, condenser.Kfr_cold) annotation (Line(points={{-22,-24},{-14,
+          -24},{-14,4},{-11,4}}, color={0,0,127}));
+  connect(condenser.C_hot_out, Condensate_Temp_sensor.C_in)
+    annotation (Line(points={{0,-8},{0,-22}}, color={28,108,200}));
+  connect(condensate_sink.C_in, Condensate_Temp_sensor.C_out)
+    annotation (Line(points={{0,-53},{0,-42}}, color={28,108,200}));
+  connect(Condensate_Temp_sensor.T_sensor, Condensate_Temp)
+    annotation (Line(points={{10,-32},{30,-32}}, color={0,0,127}));
+  connect(condenser.C_incond, C_incond.y)
+    annotation (Line(points={{6.4,11},{8,12},{8,21}}, color={0,0,127}));
+  connect(Cond_Pressure_sensor.P_sensor, Cond_Pressure)
+    annotation (Line(points={{10,48},{22,48}}, color={0,0,127}));
+  connect(Circ_Water_Outlet_Temp_sensor.T_sensor, Circ_Water_Outlet_Temp)
+    annotation (Line(points={{32,10},{30,10},{30,24}}, color={0,0,127}));
+  connect(Circ_Water_Outlet_Press_sensor.P_sensor, Circ_Water_Outlet_Press)
+    annotation (Line(points={{62,10},{62,30},{58,30}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,80}})),
                         Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_faulty.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_faulty.mo
@@ -1,21 +1,16 @@
 within MetroscopeModelingLibrary.Tests.WaterSteam.HeatExchangers;
 model Condenser_faulty
-  extends Condenser_direct(
+  extends Condenser_direct     (
       condenser(faulty = true));
 
-  Real Fault_fouling(start=0);
-  Real Fault_air_intake(start=0);
-  Real Fault_Qv_cold_in_decrease(start=0);
+  input Real Fault_fouling(start=0);
+  input Real Fault_air_intake(start=0);
+  input Real Fault_Qv_cold_in_decrease(start=0);
 
 equation
 
-  // Failure input
-  Fault_fouling = 0 + 10*time;
-  Fault_air_intake = 0 + 1e-3 * time;
-  Fault_Qv_cold_in_decrease = 0 + 10 * time;
-
   // Failure definition
-  condenser.fouling = Fault_fouling;
+  condenser.fouling = Fault_fouling + 10*time; // Study the fouling fault
   condenser.air_intake = Fault_air_intake;
   condenser.Qv_cold_in_decrease = Fault_Qv_cold_in_decrease;
 

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Condenser_reverse.mo
@@ -6,22 +6,9 @@ model Condenser_reverse
     // Boundary conditions
   input Utilities.Units.MassFlowRate Q_turbine(start=150) "kg/s";
   input Utilities.Units.SpecificEnthalpy h_turbine(start=1500e3);
-  input Real P_cold_source(start=5, min=0, nominal=10) "barA";
-  input Real T_cold_source(start = 15, min = 0, nominal = 50) "degC";
 
-    // Parameters
-  parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.Height water_height=1;
-  parameter Real C_incond = 0;
-  parameter Utilities.Units.Pressure P_offset=0;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=1;
-  parameter Utilities.Units.VolumeFlowRate Qv_cold=3.82;
-
-    // Calibrated parameters
-  output Utilities.Units.HeatExchangeCoefficient Kth;
-
-    // Inputs for calibration
-  input Real P_cond(start = 0.19e5) "Pa";
+  // Specifications, if "input_specs" is set to true
+  input Real hotwell_level( start = 1);
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source turbine_outlet annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -30,57 +17,135 @@ model Condenser_reverse
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink condensate_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-44})));
+        origin={0,-58})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cooling_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=0,
-        origin={-44,0})));
+        origin={-86,0})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cooling_sink annotation (Placement(transformation(extent={{74,-10},{94,10}})));
-  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser annotation (Placement(transformation(extent={{-10,-8},{10,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor condensate_temperature_sensor annotation (Placement(transformation(
+  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Condenser condenser(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-10,-8},{10,10}})));
+  Sensors_Control.WaterSteam.TemperatureSensor Circ_Water_Outlet_Temp_sensor(
+    sensor_function="Calibration",
+    causality="Qv cold",
+    T_start=28.4,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Utilities.Interfaces.CalibrationInput Circ_Water_Outlet_Temp annotation (
+      Placement(transformation(extent={{28,18},{36,26}}), iconTransformation(
+          extent={{-266,-72},{-226,-32}})));
+  Sensors_Control.WaterSteam.PressureSensor Circ_Water_Outlet_Press_sensor(
+    sensor_function="Calibration",
+    causality="Kfr cold",
+    P_start=1,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{52,-10},{72,10}})));
+  Utilities.Interfaces.CalibrationInput Circ_Water_Outlet_Press annotation (
+      Placement(transformation(extent={{56,18},{64,26}}), iconTransformation(
+          extent={{-266,-72},{-226,-32}})));
+  Sensors_Control.WaterSteam.PressureSensor Cond_Pressure_sensor(
+    sensor_function="Calibration",
+    causality="Kth",
+    P_start=0.19,
+    signal_unit="barA",
+    display_unit="barA") annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-24})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor circulating_water_T_out_sensor annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=0,
-        origin={30,0})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor circulating_water_P_out_sensor annotation (Placement(transformation(extent={{50,-10},{70,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cond_sensor annotation (Placement(transformation(
+        origin={0,48})));
+  Utilities.Interfaces.CalibrationInput Cond_Pressure annotation (Placement(
+        transformation(extent={{22,44},{30,52}}), iconTransformation(extent={{-266,
+            -72},{-226,-32}})));
+  Sensors_Control.WaterSteam.TemperatureSensor Circ_Water_Inlet_Temp_sensor(
+    sensor_function="BC",
+    T_start=15,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+  Sensors_Control.WaterSteam.PressureSensor Circ_Water_Inlet_Press_sensor(
+    sensor_function="BC",
+    P_start=1.1,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+  Utilities.Interfaces.BoundaryCondition Circ_Water_Inlet_Temp annotation (
+      Placement(transformation(extent={{-64,18},{-56,26}}), iconTransformation(
+          extent={{-268,-24},{-228,16}})));
+  Utilities.Interfaces.BoundaryCondition Circ_Water_Inlet_Press
+                                                               annotation (
+      Placement(transformation(extent={{-34,18},{-26,26}}), iconTransformation(
+          extent={{-268,-24},{-228,16}})));
+  Utilities.Interfaces.RealOutput Kth annotation (Placement(transformation(
+          extent={{-10,18},{-2,26}}), iconTransformation(extent={{-134,-16},{-114,
+            6}})));
+  Utilities.Interfaces.RealOutput Qv_cold_in annotation (Placement(
+        transformation(extent={{-24,28},{-16,36}}), iconTransformation(extent={{
+            -134,-16},{-114,6}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-26,-28},{-18,-20}}), iconTransformation(extent={{-134,-16},{
+            -114,6}})));
+  Sensors_Control.WaterSteam.TemperatureSensor Condensate_Temp_sensor
+    annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,40})));
+        origin={0,-32})));
+  Utilities.Interfaces.RealOutput Condensate_Temp annotation (Placement(
+        transformation(extent={{26,-36},{34,-28}}), iconTransformation(extent={{
+            -194,-30},{-174,-10}})));
+  Utilities.Interfaces.RealExpression C_incond(y=0)
+    annotation (Placement(transformation(extent={{-2,16},{18,36}})));
 equation
 
   // Boundary Conditions
   turbine_outlet.h_out = h_turbine;
   turbine_outlet.Q_out = -Q_turbine;
 
-  cooling_source.P_out = P_cold_source*1e5;
-  cooling_source.T_out = 273.15 + T_cold_source;
+  // Specifications, if "input_specs" is set to true
+  condenser.water_height = hotwell_level;
+  condenser.S = 50000;
 
-  // Parameters
-  condenser.S = S;
-  condenser.water_height = water_height;
-  condenser.C_incond = C_incond;
-  condenser.P_offset = P_offset;
-  condenser.Kfr_cold = Kfr_cold;
-  condenser.Qv_cold_in = Qv_cold;
-
-  // Calibrated Parameters
-  condenser.Kth = Kth;
-
-  // Inputs for calibration
-  P_cond_sensor.P = P_cond;
-
-  connect(condenser.C_cold_in, cooling_source.C_out) annotation (Line(points={{-10,0},{-39,0}}, color={28,108,200}));
-  connect(condenser.C_hot_out, condensate_temperature_sensor.C_in) annotation (Line(points={{0,-8},{0,-11},{1.77636e-15,-11},{1.77636e-15,-14}}, color={28,108,200}));
-  connect(condensate_sink.C_in, condensate_temperature_sensor.C_out) annotation (Line(points={{8.88178e-16,-39},{8.88178e-16,-36.5},{-1.77636e-15,-36.5},{-1.77636e-15,-34}}, color={28,108,200}));
-  connect(condenser.C_cold_out, circulating_water_T_out_sensor.C_in) annotation (Line(points={{9.8,0},{20,0}}, color={28,108,200}));
-  connect(circulating_water_T_out_sensor.C_out, circulating_water_P_out_sensor.C_in) annotation (Line(points={{40,0},{50,0}}, color={28,108,200}));
-  connect(circulating_water_P_out_sensor.C_out, cooling_sink.C_in) annotation (Line(points={{70,0},{79,0}}, color={28,108,200}));
-  connect(turbine_outlet.C_out, P_cond_sensor.C_in) annotation (Line(points={{-8.88178e-16,73},{-8.88178e-16,61.5},{1.77636e-15,61.5},{1.77636e-15,50}}, color={28,108,200}));
-  connect(condenser.C_hot_in, P_cond_sensor.C_out) annotation (Line(points={{0,10.2},{0,20.1},{-1.77636e-15,20.1},{-1.77636e-15,30}}, color={28,108,200}));
+  connect(condenser.C_cold_out, Circ_Water_Outlet_Temp_sensor.C_in)
+    annotation (Line(points={{9.8,0},{22,0}}, color={28,108,200}));
+  connect(Circ_Water_Outlet_Temp_sensor.T_sensor, Circ_Water_Outlet_Temp)
+    annotation (Line(points={{32,10},{32,22}}, color={0,0,127}));
+  connect(Circ_Water_Outlet_Temp_sensor.C_out, Circ_Water_Outlet_Press_sensor.C_in)
+    annotation (Line(points={{42,0},{52,0}}, color={28,108,200}));
+  connect(cooling_sink.C_in, Circ_Water_Outlet_Press_sensor.C_out)
+    annotation (Line(points={{79,0},{72,0}}, color={28,108,200}));
+  connect(Circ_Water_Outlet_Press_sensor.P_sensor, Circ_Water_Outlet_Press)
+    annotation (Line(points={{62,10},{62,22},{60,22}}, color={0,0,127}));
+  connect(Cond_Pressure_sensor.C_in, turbine_outlet.C_out)
+    annotation (Line(points={{0,58},{0,73}}, color={28,108,200}));
+  connect(Cond_Pressure_sensor.C_out, condenser.C_hot_in)
+    annotation (Line(points={{0,38},{0,10.2}}, color={28,108,200}));
+  connect(Cond_Pressure_sensor.P_sensor, Cond_Pressure)
+    annotation (Line(points={{10,48},{26,48}}, color={0,0,127}));
+  connect(Circ_Water_Inlet_Temp_sensor.C_in, cooling_source.C_out)
+    annotation (Line(points={{-70,0},{-81,0}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Press_sensor.C_in, Circ_Water_Inlet_Temp_sensor.C_out)
+    annotation (Line(points={{-40,0},{-50,0}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Press_sensor.C_out, condenser.C_cold_in)
+    annotation (Line(points={{-20,0},{-10,0}}, color={28,108,200}));
+  connect(Circ_Water_Inlet_Temp_sensor.T_sensor, Circ_Water_Inlet_Temp)
+    annotation (Line(points={{-60,10},{-60,22}}, color={0,0,127}));
+  connect(Circ_Water_Inlet_Press_sensor.P_sensor, Circ_Water_Inlet_Press)
+    annotation (Line(points={{-30,10},{-30,22}}, color={0,0,127}));
+  connect(condenser.Kth, Kth)
+    annotation (Line(points={{-6.4,11},{-6,11},{-6,22}}, color={0,0,127}));
+  connect(condenser.Qv_cold_in, Qv_cold_in) annotation (Line(points={{-11,8},{-16,
+          8},{-16,24},{-20,24},{-20,32}}, color={0,0,127}));
+  connect(Kfr_cold, condenser.Kfr_cold) annotation (Line(points={{-22,-24},{-14,
+          -24},{-14,4},{-11,4}}, color={0,0,127}));
+  connect(condenser.C_hot_out, Condensate_Temp_sensor.C_in)
+    annotation (Line(points={{0,-8},{0,-22}}, color={28,108,200}));
+  connect(condensate_sink.C_in, Condensate_Temp_sensor.C_out)
+    annotation (Line(points={{0,-53},{0,-42}}, color={28,108,200}));
+  connect(Condensate_Temp_sensor.T_sensor, Condensate_Temp)
+    annotation (Line(points={{10,-32},{30,-32}}, color={0,0,127}));
+  connect(condenser.C_incond, C_incond.y)
+    annotation (Line(points={{6.4,11},{8,12},{8,21}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,80}})),
                         Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/DryReheater_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/DryReheater_direct.mo
@@ -8,18 +8,13 @@ model DryReheater_direct
   input Real P_cold_source(start=50, min=0, nominal=50) "bar";
   input Utilities.Units.PositiveMassFlowRate Q_cold(start=500) "kg/s";
   input Real T_cold_in(start=50) "degC";
-  input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.5e6) "J/kg";
-
-  // Parameters
-  parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth=50e3;
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot=0;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=500;
-                                                      // About 1 bar of pressure loss in the reheater
+  input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.9e6) "J/kg";
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.DryReheater dryReheater annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{68,-10},{88,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.DryReheater dryReheater(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
@@ -27,7 +22,31 @@ model DryReheater_direct
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-30})));
+        origin={0,-36})));
+  Utilities.Interfaces.RealOutput Kth annotation (Placement(transformation(
+          extent={{-22,14},{-14,22}}), iconTransformation(extent={{-34,2},{-14,22}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-34,6},{-26,14}}), iconTransformation(extent={{-34,2},{-14,22}})));
+  Sensors_Control.WaterSteam.PressureSensor P_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kfr_cold",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kth",
+    T_start=70,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  Utilities.Interfaces.RealOutput P_cold_sink annotation (Placement(
+        transformation(extent={{26,18},{34,26}}), iconTransformation(extent={{-34,
+            2},{-14,22}})));
+  Utilities.Interfaces.RealOutput T_cold_sink annotation (Placement(
+        transformation(extent={{52,16},{60,24}}), iconTransformation(extent={{-34,
+            2},{-14,22}})));
 equation
 
   // Boundary conditions
@@ -38,18 +57,31 @@ equation
   cold_source.T_out = T_cold_in + 273.15;
   cold_source.Q_out = -Q_cold;
 
-  // Component parameters
-  dryReheater.S = S;
-  dryReheater.Kth = Kth;
-  dryReheater.Kfr_hot = Kfr_hot;
-  dryReheater.Kfr_cold = Kfr_cold;
+  // Calibrated parameters
+  Kth = 50e3;
+  Kfr_cold = 500;
 
-  connect(dryReheater.C_cold_out, cold_sink.C_in)
-    annotation (Line(points={{16,0},{45,0}}, color={28,108,200}));
-  connect(hot_sink.C_in, dryReheater.C_hot_out) annotation (Line(points={{8.88178e-16,
-          -25},{8.88178e-16,-20.5},{0,-20.5},{0,-8}}, color={28,108,200}));
+  // Specifications, for when "input_specs" is activated in component
+  dryReheater.S = 100;
+
   connect(hot_source.C_out, dryReheater.C_hot_in) annotation (Line(points={{-8.88178e-16,
           25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
   connect(cold_source.C_out, dryReheater.C_cold_in)
     annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
+  connect(dryReheater.C_hot_out, hot_sink.C_in) annotation (Line(points={{0,-8},
+          {0,-19.5},{8.88178e-16,-19.5},{8.88178e-16,-31}}, color={28,108,200}));
+  connect(dryReheater.Kth, Kth)
+    annotation (Line(points={{-8,10},{-18,10},{-18,18}}, color={0,0,127}));
+  connect(dryReheater.Kfr_cold, Kfr_cold) annotation (Line(points={{-18,4},{-24,
+          4},{-24,10},{-30,10}}, color={0,0,127}));
+  connect(dryReheater.C_cold_out, P_cold_sink_sensor.C_in)
+    annotation (Line(points={{16,0},{22,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.C_out, T_cold_sink_sensor.C_in)
+    annotation (Line(points={{42,0},{48,0}}, color={28,108,200}));
+  connect(cold_sink.C_in, T_cold_sink_sensor.C_out)
+    annotation (Line(points={{73,0},{68,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.P_sensor, P_cold_sink)
+    annotation (Line(points={{32,10},{32,22},{30,22}}, color={0,0,127}));
+  connect(T_cold_sink_sensor.T_sensor, T_cold_sink) annotation (Line(points={{
+          58,10},{57,10},{57,20},{56,20}}, color={0,0,127}));
 end DryReheater_direct;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/DryReheater_faulty.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/DryReheater_faulty.mo
@@ -1,22 +1,19 @@
 within MetroscopeModelingLibrary.Tests.WaterSteam.HeatExchangers;
 model DryReheater_faulty
-  extends DryReheater_direct(
+  extends DryReheater_direct     (
       dryReheater(faulty = true));
 
-  Real Fault_fouling(start=0);
-  Real Fault_partition_plate_leak(start=0);
-  Real Fault_tube_rupture_leak(start=0);
+  input Real Fault_fouling(start=0);
+  input Real Fault_partition_plate_leak(start=0);
+  input Real Fault_tube_rupture_leak(start=0);
+  input Real Fault_hot_side_partition_plate_leak( start = 0);
 
 equation
 
-  // Failure input
-  Fault_fouling = 0 + 10*time;
-  Fault_partition_plate_leak = 0 + 10*time;
-  Fault_tube_rupture_leak = 0 + 10*time;
-
   // Failure definition
-  dryReheater.fouling = Fault_fouling;
+  dryReheater.fouling = Fault_fouling + 10*time; // Investigate the fouling fault
   dryReheater.partition_plate_leak = Fault_partition_plate_leak;
   dryReheater.tube_rupture_leak = Fault_tube_rupture_leak;
+  dryReheater.hot_side_partition_plate_leak = Fault_hot_side_partition_plate_leak;
 
 end DryReheater_faulty;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/DryReheater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/DryReheater_reverse.mo
@@ -3,6 +3,7 @@ model DryReheater_reverse
 
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
+
   // Boundary conditions
   input Real P_hot_source(start=11, min=0, nominal=11) "bar";
   input Real P_cold_source(start=50, min=0, nominal=50) "bar";
@@ -10,21 +11,12 @@ model DryReheater_reverse
   input Real T_cold_in(start=50) "degC";
   input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.9e6) "J/kg";
 
-  // Component Parameters
-  parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot=0;
-
-  // Observables for calibration
-  input Real P_cold_sink(start=49, min=0, nominal=50) "bar";
-  input Real T_cold_sink(start=70, min=0, nominal=200) "degC";
-
-  // Calibrated parameters
-  output Utilities.Units.HeatExchangeCoefficient Kth;
-  output Utilities.Units.FrictionCoefficient Kfr_cold;
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{68,-10},{88,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.DryReheater dryReheater annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.DryReheater dryReheater(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
@@ -33,8 +25,31 @@ model DryReheater_reverse
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-36})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_cold_sink_sensor annotation (Placement(transformation(extent={{48,-10},{68,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cold_sink_sensor annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Utilities.Interfaces.RealOutput Kth annotation (Placement(transformation(
+          extent={{-20,18},{-12,26}}), iconTransformation(extent={{-32,6},{-12,
+            26}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-36,8},{-28,16}}), iconTransformation(extent={{-34,2},{-14,22}})));
+  Sensors_Control.WaterSteam.PressureSensor P_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kfr_cold",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kth",
+    T_start=70,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  Utilities.Interfaces.CalibrationInput P_cold_sink annotation (Placement(
+        transformation(extent={{28,20},{36,28}}), iconTransformation(extent={{-254,
+            -44},{-214,-4}})));
+  Utilities.Interfaces.CalibrationInput T_cold_sink annotation (Placement(
+        transformation(extent={{50,20},{58,28}}), iconTransformation(extent={{-254,
+            -44},{-214,-4}})));
 equation
 
   // Boundary conditions
@@ -45,25 +60,27 @@ equation
   cold_source.T_out = T_cold_in + 273.15;
   cold_source.Q_out = -Q_cold;
 
-  // Component parameters
-  dryReheater.S = S;
-  dryReheater.Kfr_hot = Kfr_hot;
-
-  // Observables for calibration
-  P_cold_sink_sensor.P_barA = P_cold_sink;
-  T_cold_sink_sensor.T_degC = T_cold_sink;
-
-  // Calibrated parameters
-  dryReheater.Kth = Kth;
-  dryReheater.Kfr_cold = Kfr_cold;
+  // Specifications, for when "input_specs" is activated in component
+  dryReheater.S = 100;
 
   connect(hot_source.C_out, dryReheater.C_hot_in) annotation (Line(points={{-8.88178e-16,
           25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
   connect(cold_source.C_out, dryReheater.C_cold_in)
     annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
-  connect(dryReheater.C_cold_out, P_cold_sink_sensor.C_in) annotation (Line(points={{16,0},{22,0}}, color={28,108,200}));
-  connect(P_cold_sink_sensor.C_out, T_cold_sink_sensor.C_in) annotation (Line(points={{42,0},{48,0}}, color={28,108,200}));
-  connect(T_cold_sink_sensor.C_out, cold_sink.C_in) annotation (Line(points={{68,0},{73,0}}, color={28,108,200}));
   connect(dryReheater.C_hot_out, hot_sink.C_in) annotation (Line(points={{0,-8},
           {0,-19.5},{8.88178e-16,-19.5},{8.88178e-16,-31}}, color={28,108,200}));
+  connect(dryReheater.Kth, Kth)
+    annotation (Line(points={{-8,10},{-16,10},{-16,22}}, color={0,0,127}));
+  connect(dryReheater.Kfr_cold, Kfr_cold) annotation (Line(points={{-18,4},{-24,
+          4},{-24,12},{-32,12}}, color={0,0,127}));
+  connect(dryReheater.C_cold_out, P_cold_sink_sensor.C_in)
+    annotation (Line(points={{16,0},{22,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.C_out, T_cold_sink_sensor.C_in)
+    annotation (Line(points={{42,0},{48,0}}, color={28,108,200}));
+  connect(cold_sink.C_in, T_cold_sink_sensor.C_out)
+    annotation (Line(points={{73,0},{68,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.P_sensor, P_cold_sink) annotation (Line(points={{32,10},
+          {32,24}},                     color={0,0,127}));
+  connect(T_cold_sink_sensor.T_sensor, T_cold_sink)
+    annotation (Line(points={{58,10},{58,24},{54,24}}, color={0,0,127}));
 end DryReheater_reverse;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/LiqLiqHX_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/LiqLiqHX_direct.mo
@@ -4,56 +4,185 @@ model LiqLiqHX_direct
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
     // Boundary conditions
-  input Real P_hot_source(start=50, min=0, nominal=10) "barA";
   input Utilities.Units.MassFlowRate Q_hot_source(start=50) "kg/s";
-  input Real T_hot_source(start = 100, min = 0, nominal = 50) "degC";
-
-  input Real P_cold_source(start=20, min=0, nominal=10) "barA";
   input Utilities.Units.MassFlowRate Q_cold_source(start=100) "kg/s";
-  input Real T_cold_source(start = 50, min = 0, nominal = 50) "degC";
 
-    // Parameters
-  parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth=500;
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot=0;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=20;
-
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.LiqLiqHX liqLiqHX annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-100,
+            -10},{-80,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{72,-10},
+            {92,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.LiqLiqHX liqLiqHX( input_specs = true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,30})));
+        origin={0,90})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-30})));
+        origin={0,-72})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-42,18},{-34,26}}), iconTransformation(extent={{-224,42},{-204,
+            62}})));
+  Utilities.Interfaces.RealOutput Kth annotation (Placement(transformation(
+          extent={{-20,22},{-12,30}}), iconTransformation(extent={{-216,42},{-196,
+            62}})));
+  Utilities.Interfaces.RealOutput Kfr_hot annotation (Placement(transformation(
+          extent={{12,18},{20,26}}), iconTransformation(extent={{-218,52},{-198,
+            72}})));
+  Sensors_Control.WaterSteam.PressureSensor P_hot_out_sensor(
+    sensor_function="Calibration",
+    causality="Kfr hot",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")                                     annotation (
+      Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,-31})));
+public
+  Sensors_Control.WaterSteam.PressureSensor P_cold_in_sensor(
+    sensor_function="BC",
+    P_start=20,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{-56,-6},{-42,8}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_in_sensor(
+    sensor_function="BC",
+    T_start=50,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{-76,-6},{-62,8}})));
+  Utilities.Interfaces.BoundaryCondition T_cold_in annotation (Placement(
+        transformation(extent={{-76,14},{-68,22}}), iconTransformation(extent={{
+            -184,-48},{-144,-8}})));
+  Utilities.Interfaces.BoundaryCondition P_cold_in annotation (Placement(
+        transformation(extent={{-60,16},{-52,24}}), iconTransformation(extent={{
+            -184,-48},{-144,-8}})));
+  Sensors_Control.WaterSteam.PressureSensor P_hot_in_sensor(
+    sensor_function="BC",
+    P_start=50,
+    signal_unit="barA",
+    display_unit="barA") annotation (Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,65})));
+  Utilities.Interfaces.BoundaryCondition P_hot_in annotation (Placement(
+        transformation(
+        extent={{-4,-4},{4,4}},
+        rotation=90,
+        origin={18,64}),  iconTransformation(extent={{-184,-48},{-144,-8}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_hot_in_sensor(
+    sensor_function="BC",
+    T_start=100,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,43})));
+  Utilities.Interfaces.BoundaryCondition T_hot_in annotation (Placement(
+        transformation(
+        extent={{-4,-4},{4,4}},
+        rotation=90,
+        origin={24,44}),  iconTransformation(extent={{-184,-48},{-144,-8}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_hot_out_sensor(
+    sensor_function="Calibration",
+    causality="Kth",
+    T_start=90,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,-53})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_out_sensor(
+    sensor_function="BC",
+    T_start=55,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{34,-6},{48,8}})));
+  Utilities.Interfaces.BoundaryCondition T_cold_out annotation (Placement(
+        transformation(
+        extent={{-4,-4},{4,4}},
+        rotation=90,
+        origin={40,18}), iconTransformation(extent={{-184,-48},{-144,-8}})));
+  Utilities.Interfaces.RealOutput T_hot_out annotation (Placement(
+        transformation(extent={{16,-58},{24,-50}}), iconTransformation(extent={{
+            -218,52},{-198,72}})));
+  Utilities.Interfaces.RealOutput P_hot_out annotation (Placement(
+        transformation(extent={{16,-36},{24,-28}}), iconTransformation(extent={{
+            -218,52},{-198,72}})));
+  Utilities.Interfaces.RealOutput P_cold_out annotation (Placement(
+        transformation(extent={{58,16},{66,24}}), iconTransformation(extent={{-218,
+            52},{-198,72}})));
+  Sensors_Control.WaterSteam.PressureSensor P_cold_out_sensor(
+    sensor_function="Calibration",
+    causality="Kfr_cold",
+    P_start=19,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{56,-6},{70,8}})));
 equation
-
-  hot_source.P_out = P_hot_source * 1e5;
-  hot_source.T_out = 273.15 + T_hot_source;
-  hot_source.Q_out = - Q_hot_source;
-
-  cold_source.P_out = P_cold_source *1e5;
-  cold_source.T_out = 273.15 + T_cold_source;
+  //hot_source.Q_out = - Q_hot_source;
   cold_source.Q_out = - Q_cold_source;
 
-  liqLiqHX.Kth = Kth;
-  liqLiqHX.Kfr_hot = Kfr_hot;
-  liqLiqHX.Kfr_cold = Kfr_cold;
+  // Calibrated parameters
+  Kth = 492;
+  Kfr_cold = 1000;
+  Kfr_hot = 40000;
 
-  connect(liqLiqHX.C_cold_out, cold_sink.C_in) annotation (Line(
-      points={{16,0},{45,0}},
-      color={28,108,200}));
-  connect(hot_sink.C_in, liqLiqHX.C_hot_out) annotation (Line(points={{8.88178e-16,
-          -25},{8.88178e-16,-20.5},{0,-20.5},{0,-8}}, color={28,108,200}));
-  connect(hot_source.C_out, liqLiqHX.C_hot_in) annotation (Line(points={{-8.88178e-16,
-          25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
-  connect(cold_source.C_out, liqLiqHX.C_cold_in)
-    annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
+  // Specifications, for if "input_specs" is set to true
+  liqLiqHX.S = 100;
+
+  connect(liqLiqHX.Kfr_cold, Kfr_cold) annotation (Line(points={{-18,3.2},{-30,3.2},
+          {-30,22},{-38,22}}, color={0,0,127}));
+  connect(liqLiqHX.Kth, Kth)
+    annotation (Line(points={{-9.6,10},{-16,10},{-16,26}}, color={0,0,127}));
+  connect(Kfr_hot, liqLiqHX.Kfr_hot) annotation (Line(points={{16,22},{16,10},{4.8,
+          10}},                  color={0,0,127}));
+  connect(cold_sink.C_in, P_cold_out_sensor.C_out)
+    annotation (Line(points={{77,0},{70,0},{70,1}}, color={28,108,200}));
+  connect(Kfr_hot, Kfr_hot)
+    annotation (Line(points={{16,22},{16,22}}, color={0,0,127}));
+  connect(liqLiqHX.C_hot_out, P_hot_out_sensor.C_in)
+    annotation (Line(points={{0,-8},{0,-24},{1,-24}}, color={28,108,200}));
+  connect(liqLiqHX.C_cold_in, P_cold_in_sensor.C_out) annotation (Line(points={{
+          -16.2,0},{-38,0},{-38,1},{-42,1}}, color={28,108,200}));
+  connect(P_cold_in_sensor.C_in, T_cold_in_sensor.C_out)
+    annotation (Line(points={{-56,1},{-62,1}}, color={28,108,200}));
+  connect(T_cold_in_sensor.C_in, cold_source.C_out)
+    annotation (Line(points={{-76,1},{-76,0},{-85,0}}, color={28,108,200}));
+  connect(T_cold_in_sensor.T_sensor, T_cold_in) annotation (Line(points={{-69,8},
+          {-68,8},{-68,12},{-72,12},{-72,18}}, color={0,0,127}));
+  connect(P_cold_in_sensor.P_sensor, P_cold_in) annotation (Line(points={{-49,8},
+          {-50.5,8},{-50.5,20},{-56,20}}, color={0,0,127}));
+  connect(hot_source.C_out, P_hot_in_sensor.C_in)
+    annotation (Line(points={{0,85},{0,72},{1,72}}, color={28,108,200}));
+  connect(P_hot_in_sensor.P_sensor, P_hot_in)
+    annotation (Line(points={{8,65},{8,64},{18,64}}, color={0,0,127}));
+  connect(P_hot_in_sensor.C_out, T_hot_in_sensor.C_in) annotation (Line(points={{1,58},{
+          0,58},{0,50},{1,50}},         color={28,108,200}));
+  connect(liqLiqHX.C_hot_in, T_hot_in_sensor.C_out)
+    annotation (Line(points={{0,8},{0,36},{1,36}}, color={28,108,200}));
+  connect(T_hot_in_sensor.T_sensor, T_hot_in) annotation (Line(points={{8,43},{10,
+          43},{10,44},{24,44}}, color={0,0,127}));
+  connect(hot_sink.C_in, T_hot_out_sensor.C_out)
+    annotation (Line(points={{0,-67},{1,-66},{1,-60}}, color={28,108,200}));
+  connect(T_hot_out_sensor.C_in, P_hot_out_sensor.C_out)
+    annotation (Line(points={{1,-46},{1,-38}}, color={28,108,200}));
+  connect(T_cold_out_sensor.C_out, P_cold_out_sensor.C_in)
+    annotation (Line(points={{48,1},{56,1}}, color={28,108,200}));
+  connect(T_cold_out_sensor.C_in, liqLiqHX.C_cold_out) annotation (Line(points={
+          {34,1},{20,1},{20,0},{16,0}}, color={28,108,200}));
+  connect(T_cold_out, T_cold_out_sensor.T_sensor)
+    annotation (Line(points={{40,18},{41,18},{41,8}}, color={28,108,200}));
+  connect(T_hot_out_sensor.T_sensor, T_hot_out) annotation (Line(points={{8,-53},
+          {8,-54.5},{20,-54.5},{20,-54}}, color={0,0,127}));
+  connect(P_hot_out_sensor.P_sensor, P_hot_out)
+    annotation (Line(points={{8,-31},{8,-32},{20,-32}}, color={0,0,127}));
+  connect(P_cold_out_sensor.P_sensor, P_cold_out) annotation (Line(points={{63,8},
+          {63,10},{62,10},{62,20}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,80}})),
+            -80},{100,100}})),
                         Diagram(coordinateSystem(preserveAspectRatio=false,
           extent={{-100,-100},{100,100}})));
 end LiqLiqHX_direct;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/LiqLiqHX_faulty.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/LiqLiqHX_faulty.mo
@@ -1,16 +1,15 @@
 within MetroscopeModelingLibrary.Tests.WaterSteam.HeatExchangers;
 model LiqLiqHX_faulty
-  extends LiqLiqHX_direct(
+    extends LiqLiqHX_direct(
       liqLiqHX(faulty = true));
 
-  Real Fault_fouling(start=0);
+  input Real Fault_fouling(start=0);
+  input Real Fault_tube_rupture( start = 0);
 
 equation
 
-  // Failure input
-  Fault_fouling = 0 + 10*time;
-
   // Failure definition
-  liqLiqHX.fouling = Fault_fouling;
+  liqLiqHX.fouling = Fault_fouling + 10*time; // Study the fouling fault
+  liqLiqHX.tube_rupture_leak = Fault_tube_rupture;
 
 end LiqLiqHX_faulty;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/LiqLiqHX_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/LiqLiqHX_reverse.mo
@@ -4,80 +4,152 @@ model LiqLiqHX_reverse
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
     // Boundary conditions
-  input Real P_hot_source(start=50, min=0, nominal=10) "barA";
-  input Utilities.Units.MassFlowRate Q_hot_source(start=50) "kg/s";
-  input Real T_hot_source(start = 100, min = 0, nominal = 50) "degC";
-
-  input Real P_cold_source(start=20, min=0, nominal=10) "barA";
   input Utilities.Units.MassFlowRate Q_cold_source(start=100) "kg/s";
-  input Real T_cold_source(start = 50, min = 0, nominal = 50) "degC";
 
-    // Parameters
-  parameter Utilities.Units.Area S=100;
-
-    // Calibrated parameters
-  output Utilities.Units.HeatExchangeCoefficient Kth;
-  output Utilities.Units.FrictionCoefficient Kfr_hot;
-  output Utilities.Units.FrictionCoefficient Kfr_cold;
-
-    // Calibration inputs
-  input Real P_cold_out(start = 19, min= 0, nominal = 10) "barA"; // Outlet pressure on cold side, to calibrate Kfr cold
-  input Real P_hot_out(start = 50, min = 0, nominal = 10) "barA"; // Outlet pressure on hot side, to calibrate Kfr hot
-  input Real T_cold_out(start = 55, min = 0, nominal = 100) "degC"; // Outlet temperature on cold side, to calibrate Kth
-
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{52,-10},{72,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.LiqLiqHX liqLiqHX annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-100,
+            -10},{-80,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{72,-10},
+            {92,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.LiqLiqHX liqLiqHX(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,30})));
+        origin={0,90})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,-36})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_cold_out_sensor annotation (Placement(transformation(extent={{22,-6},{34,6}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cold_out_sensor annotation (Placement(transformation(extent={{38,-6},{50,6}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_hot_out_sensor annotation (Placement(transformation(
-        extent={{-6,-6},{6,6}},
+        origin={0,-72})));
+  Utilities.Interfaces.RealOutput Cond_Kth_subc annotation (Placement(
+        transformation(extent={{-20,22},{-12,30}}), iconTransformation(extent={{
+            -216,42},{-196,62}})));
+  Utilities.Interfaces.RealOutput Kfr_hot annotation (Placement(transformation(
+          extent={{12,18},{20,26}}), iconTransformation(extent={{-218,52},{-198,
+            72}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_out_sensor(
+    sensor_function="BC",
+    T_start=55,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{36,-6},{50,8}})));
+  Sensors_Control.WaterSteam.PressureSensor P_hot_out_sensor(
+    sensor_function="Calibration",
+    causality="Kfr hot",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")                                     annotation (
+      Placement(transformation(
+        extent={{-7,-7},{7,7}},
         rotation=270,
-        origin={0,-18})));
+        origin={1,-31})));
+  Utilities.Interfaces.CalibrationInput P_hot_out annotation (Placement(
+        transformation(extent={{16,-36},{24,-28}}), iconTransformation(extent={{
+            -192,-48},{-152,-8}})));
+  Utilities.Interfaces.CalibrationInput T_hot_out annotation (Placement(
+        transformation(extent={{14,-54},{22,-46}}), iconTransformation(extent={{
+            -192,-48},{-152,-8}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_in_sensor(
+    sensor_function="BC",
+    T_start=50,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{-76,-6},{-62,8}})));
+  Utilities.Interfaces.BoundaryCondition T_cold_in annotation (Placement(
+        transformation(extent={{-76,14},{-68,22}}), iconTransformation(extent={{
+            -184,-48},{-144,-8}})));
+public
+  Sensors_Control.WaterSteam.PressureSensor P_hot_in_sensor(
+    sensor_function="BC",
+    P_start=50,
+    signal_unit="barA",
+    display_unit="barA") annotation (Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,65})));
+  Utilities.Interfaces.BoundaryCondition P_hot_in annotation (Placement(
+        transformation(
+        extent={{-4,-4},{4,4}},
+        rotation=90,
+        origin={18,64}),  iconTransformation(extent={{-184,-48},{-144,-8}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_hot_in_sensor(
+    sensor_function="BC",
+    T_start=100,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,43})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_hot_out_sensor(
+    sensor_function="Calibration",
+    causality="Kth",
+    T_start=90,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-7,-7},{7,7}},
+        rotation=270,
+        origin={1,-51})));
+  Utilities.Interfaces.RealOutput T_hot_in
+                                          annotation (Placement(transformation(
+          extent={{14,38},{22,46}}), iconTransformation(extent={{-218,52},{-198,
+            72}})));
+  Utilities.Interfaces.RealExpression Cond_Kfr_cold_subc
+    annotation (Placement(transformation(extent={{-48,8},{-28,28}})));
+  Utilities.Interfaces.BoundaryCondition T_cold_out annotation (Placement(
+        transformation(
+        extent={{-4,-4},{4,4}},
+        rotation=90,
+        origin={50,28}), iconTransformation(extent={{-184,-48},{-144,-8}})));
 equation
 
   // Boundary conditions
-  hot_source.P_out = P_hot_source * 1e5;
-  hot_source.T_out = 273.15 + T_hot_source;
-  hot_source.Q_out = - Q_hot_source;
-  cold_source.P_out = P_cold_source *1e5;
-  cold_source.T_out = 273.15 + T_cold_source;
   cold_source.Q_out = - Q_cold_source;
+  cold_source.P_out = 20*6894.75729;
+  hot_source.T_out = 100+273.15;
 
+  // Specifications, for if "input_specs" is set to true
+  liqLiqHX.S = 100;
 
-  // Inputs for calibration
-  T_cold_out_sensor.T_degC = T_cold_out;
-  P_cold_out_sensor.P_barA = P_cold_out;
-  P_hot_out_sensor.P_barA = P_hot_out;
-
-  // Calibrated parameters
-  liqLiqHX.Kth = Kth;
-  liqLiqHX.Kfr_hot = Kfr_hot;
-  liqLiqHX.Kfr_cold = Kfr_cold;
-
-  connect(hot_source.C_out, liqLiqHX.C_hot_in) annotation (Line(points={{-8.88178e-16,
-          25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
-  connect(cold_source.C_out, liqLiqHX.C_cold_in)
-    annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
-  connect(P_cold_out_sensor.C_out, cold_sink.C_in)
-    annotation (Line(points={{50,0},{57,0}}, color={28,108,200}));
-  connect(P_cold_out_sensor.C_in, T_cold_out_sensor.C_out)
-    annotation (Line(points={{38,0},{34,0}}, color={28,108,200}));
-  connect(T_cold_out_sensor.C_in, liqLiqHX.C_cold_out)
-    annotation (Line(points={{22,0},{16,0}}, color={28,108,200}));
-  connect(hot_sink.C_in, P_hot_out_sensor.C_out) annotation (Line(points={{8.88178e-16,
-          -31},{8.88178e-16,-27.5},{-1.11022e-15,-27.5},{-1.11022e-15,-24}},
-        color={28,108,200}));
-  connect(liqLiqHX.C_hot_out, P_hot_out_sensor.C_in) annotation (Line(points={{0,
-          -8},{0,-10},{1.11022e-15,-10},{1.11022e-15,-12}}, color={28,108,200}));
+  connect(liqLiqHX.Kth, Cond_Kth_subc)
+    annotation (Line(points={{-9.6,10},{-16,10},{-16,26}}, color={0,0,127}));
+  connect(Kfr_hot, liqLiqHX.Kfr_hot) annotation (Line(points={{16,22},{16,10},{4.8,
+          10}},                  color={0,0,127}));
+  connect(liqLiqHX.C_cold_out, T_cold_out_sensor.C_in)
+    annotation (Line(points={{16,0},{16,1},{36,1}}, color={28,108,200}));
+  connect(Kfr_hot, Kfr_hot)
+    annotation (Line(points={{16,22},{16,22}}, color={0,0,127}));
+  connect(liqLiqHX.C_hot_out, P_hot_out_sensor.C_in)
+    annotation (Line(points={{0,-8},{0,-24},{1,-24}}, color={28,108,200}));
+  connect(P_hot_out, P_hot_out_sensor.P_sensor)
+    annotation (Line(points={{20,-32},{20,-31},{8,-31}}, color={28,108,200}));
+  connect(T_cold_in_sensor.C_in, cold_source.C_out)
+    annotation (Line(points={{-76,1},{-76,0},{-85,0}}, color={28,108,200}));
+  connect(T_cold_in_sensor.T_sensor, T_cold_in) annotation (Line(points={{-69,8},
+          {-68,8},{-68,12},{-72,12},{-72,18}}, color={0,0,127}));
+  connect(hot_source.C_out, P_hot_in_sensor.C_in)
+    annotation (Line(points={{0,85},{0,72},{1,72}}, color={28,108,200}));
+  connect(P_hot_in_sensor.P_sensor, P_hot_in)
+    annotation (Line(points={{8,65},{8,64},{18,64}}, color={0,0,127}));
+  connect(P_hot_in_sensor.C_out, T_hot_in_sensor.C_in) annotation (Line(points={
+          {1,58},{2,58},{2,50},{1,50}}, color={28,108,200}));
+  connect(liqLiqHX.C_hot_in, T_hot_in_sensor.C_out)
+    annotation (Line(points={{0,8},{0,36},{1,36}}, color={28,108,200}));
+  connect(hot_sink.C_in, T_hot_out_sensor.C_out)
+    annotation (Line(points={{0,-67},{1,-66},{1,-58}}, color={28,108,200}));
+  connect(T_hot_out_sensor.C_in, P_hot_out_sensor.C_out)
+    annotation (Line(points={{1,-44},{1,-38}}, color={28,108,200}));
+  connect(T_hot_out_sensor.T_sensor, T_hot_out)
+    annotation (Line(points={{8,-51},{8,-50},{18,-50}}, color={0,0,127}));
+  connect(T_hot_in_sensor.T_sensor,T_hot_in)
+    annotation (Line(points={{8,43},{8,42},{18,42}}, color={0,0,127}));
+  connect(cold_sink.C_in, T_cold_out_sensor.C_out) annotation (Line(points={{77,
+          0},{54,0},{54,1},{50,1}}, color={28,108,200}));
+  connect(liqLiqHX.Kfr_cold, Cond_Kfr_cold_subc.y)
+    annotation (Line(points={{-18,3.2},{-38,3.2},{-38,13}}, color={0,0,127}));
+  connect(T_cold_in_sensor.C_out, liqLiqHX.C_cold_in) annotation (Line(points={{
+          -62,1},{-26,1},{-26,0},{-16.2,0}}, color={28,108,200}));
+  connect(T_cold_out, T_cold_out_sensor.T_sensor) annotation (Line(points={{50,28},
+          {50,12},{43,12},{43,8}}, color={28,108,200}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -80},{100,100}})),
                         Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_direct.mo
@@ -3,56 +3,125 @@ model Reheater_direct
 
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
+  // This component represents an NPP reheater where the drains from the upstream heater join the extraction steam of the top of the heater,
+  // then pass through both the condensing and subcooling zones. It's identical to Reheater_reverse_connectors example except for the drains source.
+
   // Boundary conditions
   input Real P_hot_source(start=11, min=0, nominal=11) "bar";
   input Real P_cold_source(start=50, min=0, nominal=50) "bar";
   input Utilities.Units.PositiveMassFlowRate Q_cold(start=500) "kg/s";
   input Real T_cold_in(start=50) "degC";
-  input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.5e6) "J/kg";
+  input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.9e6) "J/kg";
 
-  // Parameters
-  parameter Utilities.Units.Area S_tot=100;
-  parameter Utilities.Units.Fraction level=0.3;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth_cond=61e3;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth_subc=8e3;
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot=0;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=0;
+  input Real Q_drains( start=95) "kg/s";
+  input Real h_drains( start = 8e5) "J/kg";
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Reheater reheater annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{68,-10},{88,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Reheater reheater( input_specs = true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source Extr_source
+    annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,30})));
+        origin={0,54})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
+        origin={0,-56})));
+  Utilities.Interfaces.RealOutput Kth_cond annotation (Placement(transformation(
+          extent={{-34,-22},{-26,-14}}), iconTransformation(extent={{-254,-48},{
+            -234,-28}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-40,12},{-32,20}}), iconTransformation(extent={{-250,-32},{-230,
+            -12}})));
+  Utilities.Interfaces.RealOutput Kth_subc annotation (Placement(transformation(
+          extent={{-22,26},{-14,34}}), iconTransformation(extent={{-252,-40},{-232,
+            -20}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_drains_sensor(
+    sensor_function="Calibration",
+    causality="Kth_subc",
+    T_start=80,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
         origin={0,-30})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kth_cond",
+    T_start=70,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Sensors_Control.WaterSteam.PressureSensor P_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kfr_cold",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source Drains_source
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={40,44})));
+  Utilities.Interfaces.RealOutput T_drains annotation (Placement(transformation(
+          extent={{18,-34},{26,-26}}), iconTransformation(extent={{-254,-48},{-234,
+            -28}})));
+  Utilities.Interfaces.RealOutput T_cold_sink annotation (Placement(
+        transformation(extent={{26,16},{34,24}}), iconTransformation(extent={{-254,
+            -48},{-234,-28}})));
+  Utilities.Interfaces.RealOutput P_cold_sink annotation (Placement(
+        transformation(extent={{54,18},{62,26}}), iconTransformation(extent={{-254,
+            -48},{-234,-28}})));
 equation
 
   // Boundary conditions
-  hot_source.P_out = P_hot_source*1e5;
-  hot_source.h_out = hot_source_h_out;
+  Extr_source.P_out = P_hot_source*1e5;
+  Extr_source.h_out = hot_source_h_out;
 
   cold_source.P_out = P_cold_source*1e5;
   cold_source.T_out = T_cold_in + 273.15;
   cold_source.Q_out = -Q_cold;
 
-  // Component parameters
-  reheater.S = S_tot;
-  reheater.Kth_cond = Kth_cond;
-  reheater.Kth_subc = Kth_subc;
-  reheater.Kfr_hot = Kfr_hot;
-  reheater.Kfr_cold = Kfr_cold;
-  reheater.level = level;
+  Drains_source.Q_out = -Q_drains;
+  Drains_source.h_out = h_drains;
 
-  connect(reheater.C_cold_out, cold_sink.C_in)
-    annotation (Line(points={{16,0},{45,0}}, color={28,108,200}));
-  connect(hot_sink.C_in, reheater.C_hot_out) annotation (Line(points={{8.88178e-16,
-          -25},{8.88178e-16,-20.5},{0,-20.5},{0,-8}}, color={28,108,200}));
-  connect(hot_source.C_out, reheater.C_hot_in) annotation (Line(points={{-8.88178e-16,
-          25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
+    // Calibrated inputs
+  Kth_cond = 61e3;
+  Kth_subc = 8e3;
+  Kfr_cold = 0;
+
+  // Specification, for if "input_specs" is set to true
+  reheater.S = 100;
+
+  connect(Extr_source.C_out, reheater.C_hot_in)
+    annotation (Line(points={{0,49},{0,8}}, color={28,108,200}));
   connect(cold_source.C_out, reheater.C_cold_in)
     annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
+  connect(reheater.Kth_cond, Kth_cond) annotation (Line(points={{-7.8,-10},{-30,
+          -10},{-30,-18}}, color={0,0,127}));
+  connect(reheater.Kfr_cold, Kfr_cold) annotation (Line(points={{-18,4},{-26,4},
+          {-26,16},{-36,16}}, color={0,0,127}));
+  connect(reheater.Kth_subc, Kth_subc)
+    annotation (Line(points={{-8,10},{-18,10},{-18,30}}, color={0,0,127}));
+  connect(cold_sink.C_in, P_cold_sink_sensor.C_out)
+    annotation (Line(points={{73,0},{68,0}}, color={28,108,200}));
+  connect(reheater.C_cold_out, T_cold_sink_sensor.C_in)
+    annotation (Line(points={{16,0},{22,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.C_in, T_cold_sink_sensor.C_out)
+    annotation (Line(points={{48,0},{42,0}}, color={28,108,200}));
+  connect(hot_sink.C_in, T_drains_sensor.C_out)
+    annotation (Line(points={{0,-51},{0,-40}}, color={28,108,200}));
+  connect(reheater.C_hot_out, T_drains_sensor.C_in)
+    annotation (Line(points={{0,-8},{0,-20}}, color={28,108,200}));
+  connect(Drains_source.C_out, reheater.C_hot_in)
+    annotation (Line(points={{35,44},{0,44},{0,8}}, color={28,108,200}));
+  connect(T_drains_sensor.T_sensor, T_drains)
+    annotation (Line(points={{10,-30},{22,-30}}, color={0,0,127}));
+  connect(T_cold_sink_sensor.T_sensor, T_cold_sink) annotation (Line(points={{
+          32,10},{31,10},{31,20},{30,20}}, color={0,0,127}));
+  connect(P_cold_sink_sensor.P_sensor, P_cold_sink)
+    annotation (Line(points={{58,10},{58,22}}, color={0,0,127}));
 end Reheater_direct;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_faulty.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_faulty.mo
@@ -1,25 +1,21 @@
 within MetroscopeModelingLibrary.Tests.WaterSteam.HeatExchangers;
 model Reheater_faulty
-  extends Reheater_direct(
+  extends Reheater_direct              (
       reheater(faulty = true));
 
-  Real Fault_fouling(start=0);
-  Real Fault_water_level_rise(start=0);
-  Real Fault_partition_plate_leak(start=0);
-  Real Fault_tube_rupture_leak(start=0);
+  input Real Fault_fouling(start=0);
+  input Real Fault_water_level_rise(start=0);
+  input Real Fault_partition_plate_leak(start=0);
+  input Real Fault_tube_rupture_leak(start=0);
+  input Real Fault_hot_side_partition_plate_leak( start = 0);
 
 equation
 
-  // Failure input
-  Fault_fouling = 0 + 10*time;
-  Fault_water_level_rise = 0 - 0.1*time;
-  Fault_partition_plate_leak = 0 + 10*time;
-  Fault_tube_rupture_leak = 0 + 5*time;
-
   // Failure definition
-  reheater.fouling = Fault_fouling;
+  reheater.fouling = Fault_fouling + 10*time; // Study the fouling fault
   reheater.water_level_rise = Fault_water_level_rise;
   reheater.partition_plate_leak = Fault_partition_plate_leak;
   reheater.tube_rupture_leak = Fault_tube_rupture_leak;
+  reheater.hot_side_partition_plate_leak = Fault_hot_side_partition_plate_leak;
 
 end Reheater_faulty;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_reverse.mo
@@ -3,6 +3,8 @@ model Reheater_reverse
 
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
+  // Represents an NPP reheater where the drains from the upstream heater join the extraction steam before the condensing section inlet. It's identical to rehehater_sideDrainsInlet except for the drains source
+
   // Boundary conditions
   input Real P_hot_source(start=11, min=0, nominal=11) "bar";
   input Real P_cold_source(start=50, min=0, nominal=50) "bar";
@@ -10,75 +12,110 @@ model Reheater_reverse
   input Real T_cold_in(start=50) "degC";
   input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.9e6) "J/kg";
 
-  // Component Parameters
-  parameter Utilities.Units.Area S_tot=100;
-  parameter Utilities.Units.Fraction level=0.3;
-
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot=0;
-
-  // Observables for calibration
-  input Real P_cold_sink(start=49, min=0, nominal=50) "bar";
-  input Real T_cold_sink(start=70, min=0, nominal=200) "degC";
-  input Real T_drains(start=80, min=0, nominal=200) "degC";
-
-  // Calibrated parameters
-  output Utilities.Units.HeatExchangeCoefficient Kth_cond;
-  output Utilities.Units.FrictionCoefficient Kfr_cold;
-  output Utilities.Units.HeatExchangeCoefficient Kth_subc;
+  input Real Q_drains( start=95) "kg/s";
+  input Real h_drains( start = 8e5) "J/kg";
 
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{68,-10},{88,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Reheater reheater annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_source annotation (Placement(transformation(
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Reheater reheater( input_specs = true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source Extr_source
+    annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={0,30})));
+        origin={0,54})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-56})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_cold_sink_sensor annotation (Placement(transformation(extent={{24,-10},{44,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor P_cold_sink_sensor annotation (Placement(transformation(extent={{48,-10},{68,10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor T_drains_sensor(P_0=1100000)
-                                                                                 annotation (Placement(transformation(
+  Utilities.Interfaces.RealOutput Kth_cond annotation (Placement(transformation(
+          extent={{-34,-22},{-26,-14}}), iconTransformation(extent={{-254,-48},{
+            -234,-28}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-40,12},{-32,20}}), iconTransformation(extent={{-250,-32},{-230,
+            -12}})));
+  Utilities.Interfaces.RealOutput Kth_subc annotation (Placement(transformation(
+          extent={{-22,26},{-14,34}}), iconTransformation(extent={{-252,-40},{-232,
+            -20}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_drains_sensor(
+    sensor_function="Calibration",
+    causality="Kth_subc",
+    T_start=80,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-30})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kth_cond",
+    T_start=70,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Sensors_Control.WaterSteam.PressureSensor P_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kfr_cold",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  Utilities.Interfaces.RealInput T_drains annotation (Placement(transformation(
+          extent={{22,-34},{30,-26}}), iconTransformation(extent={{-250,28},{-210,
+            68}})));
+  Utilities.Interfaces.RealInput T_cold_sink annotation (Placement(
+        transformation(extent={{26,18},{34,26}}), iconTransformation(extent={{-262,
+            44},{-222,84}})));
+  Utilities.Interfaces.RealInput P_cold_sink annotation (Placement(
+        transformation(extent={{52,20},{60,28}}), iconTransformation(extent={{-248,
+            48},{-208,88}})));
+  MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source Drains_source
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={40,44})));
 equation
 
   // Boundary conditions
-  hot_source.P_out = P_hot_source*1e5;
-  hot_source.h_out = hot_source_h_out;
+  Extr_source.P_out = P_hot_source*1e5;
+  Extr_source.h_out = hot_source_h_out;
 
   cold_source.P_out = P_cold_source*1e5;
   cold_source.T_out = T_cold_in + 273.15;
   cold_source.Q_out = -Q_cold;
 
-  // Component parameters
-  reheater.S = S_tot;
-  reheater.Kfr_hot = Kfr_hot;
-  reheater.level = level;
+  Drains_source.Q_out = -Q_drains;
+  Drains_source.h_out = h_drains;
 
-  // Observables for calibration
-  P_cold_sink_sensor.P_barA = P_cold_sink;
-  T_cold_sink_sensor.T_degC = T_cold_sink;
-  T_drains_sensor.T_degC = T_drains;
+  // Specification, for if "input_specs" is set to true
+  reheater.S = 100;
 
-  // Calibrated parameters
-  reheater.Kth_cond = Kth_cond;
-  reheater.Kfr_cold = Kfr_cold;
-  reheater.Kth_subc = Kth_subc;
-
-  connect(hot_source.C_out, reheater.C_hot_in) annotation (Line(points={{-8.88178e-16,
-          25},{-8.88178e-16,16.5},{0,16.5},{0,8}}, color={28,108,200}));
+  connect(Extr_source.C_out, reheater.C_hot_in)
+    annotation (Line(points={{0,49},{0,8}}, color={28,108,200}));
   connect(cold_source.C_out, reheater.C_cold_in)
     annotation (Line(points={{-43,0},{-16.2,0}}, color={28,108,200}));
-  connect(T_drains_sensor.C_in, reheater.C_hot_out) annotation (Line(points={{1.77636e-15,
-          -20},{1.77636e-15,-14},{0,-14},{0,-8}}, color={28,108,200}));
-  connect(T_drains_sensor.C_out, hot_sink.C_in) annotation (Line(points={{-1.77636e-15,
-          -40},{-1.77636e-15,-45.5},{8.88178e-16,-45.5},{8.88178e-16,-51}},
-        color={28,108,200}));
-  connect(reheater.C_cold_out, T_cold_sink_sensor.C_in) annotation (Line(points={{16,0},{24,0}}, color={28,108,200}));
-  connect(P_cold_sink_sensor.C_in, T_cold_sink_sensor.C_out) annotation (Line(points={{48,0},{44,0}}, color={28,108,200}));
-  connect(cold_sink.C_in, P_cold_sink_sensor.C_out) annotation (Line(points={{73,0},{68,0}}, color={28,108,200}));
+  connect(reheater.Kth_cond, Kth_cond) annotation (Line(points={{-7.8,-10},{-30,
+          -10},{-30,-18}}, color={0,0,127}));
+  connect(reheater.Kfr_cold, Kfr_cold) annotation (Line(points={{-18,4},{-26,4},
+          {-26,16},{-36,16}}, color={0,0,127}));
+  connect(reheater.Kth_subc, Kth_subc)
+    annotation (Line(points={{-8,10},{-18,10},{-18,30}}, color={0,0,127}));
+  connect(cold_sink.C_in, P_cold_sink_sensor.C_out)
+    annotation (Line(points={{73,0},{68,0}}, color={28,108,200}));
+  connect(reheater.C_cold_out, T_cold_sink_sensor.C_in)
+    annotation (Line(points={{16,0},{22,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.C_in, T_cold_sink_sensor.C_out)
+    annotation (Line(points={{48,0},{42,0}}, color={28,108,200}));
+  connect(hot_sink.C_in, T_drains_sensor.C_out)
+    annotation (Line(points={{0,-51},{0,-40}}, color={28,108,200}));
+  connect(reheater.C_hot_out, T_drains_sensor.C_in)
+    annotation (Line(points={{0,-8},{0,-20}}, color={28,108,200}));
+  connect(T_drains_sensor.T_sensor, T_drains)
+    annotation (Line(points={{10,-30},{26,-30}}, color={0,0,127}));
+  connect(T_cold_sink_sensor.T_sensor, T_cold_sink) annotation (Line(points={{32,
+          10},{32,14},{30,14},{30,22}}, color={0,0,127}));
+  connect(P_cold_sink_sensor.P_sensor, P_cold_sink)
+    annotation (Line(points={{58,10},{56,10},{56,24}}, color={0,0,127}));
+  connect(Drains_source.C_out, reheater.C_hot_in)
+    annotation (Line(points={{35,44},{0,44},{0,8}}, color={28,108,200}));
 end Reheater_reverse;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_reverse_sideDrainsInlet.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Reheater_reverse_sideDrainsInlet.mo
@@ -1,0 +1,124 @@
+within MetroscopeModelingLibrary.Tests.WaterSteam.HeatExchangers;
+model Reheater_reverse_sideDrainsInlet
+
+  extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
+
+  // Rrepresents an NPP reheater where the drains from the upstream heater joins the saturated condensning section outlet before the subcooling section inlet. It's identical to the original reheater element except for the drains source
+
+  // Boundary conditions
+  input Real P_hot_source(start=11, min=0, nominal=11) "bar";
+  input Real P_cold_source(start=50, min=0, nominal=50) "bar";
+  input Utilities.Units.PositiveMassFlowRate Q_cold(start=500) "kg/s";
+  input Real T_cold_in(start=50) "degC";
+  input Utilities.Units.SpecificEnthalpy hot_source_h_out(start=2.9e6) "J/kg";
+
+  input Real Q_drains( start=95) "kg/s";
+  input Real h_drains( start = 8e5) "J/kg";
+
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_source annotation (Placement(transformation(extent={{-58,-10},{-38,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink cold_sink annotation (Placement(transformation(extent={{74,-10},
+            {94,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source Extr_source
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,30})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink hot_sink annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,-56})));
+  Utilities.Interfaces.RealOutput Kth_cond annotation (Placement(transformation(
+          extent={{-34,-22},{-26,-14}}), iconTransformation(extent={{-254,-48},{
+            -234,-28}})));
+  Utilities.Interfaces.RealOutput Kfr_cold annotation (Placement(transformation(
+          extent={{-40,12},{-32,20}}), iconTransformation(extent={{-250,-32},{-230,
+            -12}})));
+  Utilities.Interfaces.RealOutput Kth_subc annotation (Placement(transformation(
+          extent={{-22,26},{-14,34}}), iconTransformation(extent={{-252,-40},{-232,
+            -20}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_drains_sensor(
+    sensor_function="Calibration",
+    causality="Kth_subc",
+    T_start=80,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={0,-30})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kth_cond",
+    T_start=70,
+    signal_unit="degC",
+    display_unit="degC")
+    annotation (Placement(transformation(extent={{22,-10},{42,10}})));
+  Sensors_Control.WaterSteam.PressureSensor P_cold_sink_sensor(
+    sensor_function="Calibration",
+    causality="Kfr_cold",
+    P_start=49,
+    signal_unit="barA",
+    display_unit="barA")
+    annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  Utilities.Interfaces.RealInput T_drains annotation (Placement(transformation(
+          extent={{22,-34},{30,-26}}), iconTransformation(extent={{-250,28},{-210,
+            68}})));
+  Utilities.Interfaces.RealInput T_cold_sink annotation (Placement(
+        transformation(extent={{26,18},{34,26}}), iconTransformation(extent={{-262,
+            44},{-222,84}})));
+  Utilities.Interfaces.RealInput P_cold_sink annotation (Placement(
+        transformation(extent={{52,20},{60,28}}), iconTransformation(extent={{-248,
+            48},{-208,88}})));
+  MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Reheater_sideDrainsInlet
+    reheater_sideDrainsInlet( input_specs = true)
+    annotation (Placement(transformation(extent={{-20,-8},{12,8}})));
+  MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source Drains_source
+    annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={56,-28})));
+equation
+
+  // Boundary conditions
+  Extr_source.P_out = P_hot_source*1e5;
+  Extr_source.h_out = hot_source_h_out;
+
+  cold_source.P_out = P_cold_source*1e5;
+  cold_source.T_out = T_cold_in + 273.15;
+  cold_source.Q_out = -Q_cold;
+
+  Drains_source.Q_out = -Q_drains;
+  Drains_source.h_out = h_drains;
+
+  // Specification, for if "input_specs" is set to true
+  reheater_sideDrainsInlet.S = 100;
+
+  connect(cold_sink.C_in, P_cold_sink_sensor.C_out)
+    annotation (Line(points={{79,0},{68,0}}, color={28,108,200}));
+  connect(P_cold_sink_sensor.C_in, T_cold_sink_sensor.C_out)
+    annotation (Line(points={{48,0},{42,0}}, color={28,108,200}));
+  connect(hot_sink.C_in, T_drains_sensor.C_out)
+    annotation (Line(points={{0,-51},{0,-40}}, color={28,108,200}));
+  connect(T_drains_sensor.T_sensor, T_drains)
+    annotation (Line(points={{10,-30},{26,-30}}, color={0,0,127}));
+  connect(T_cold_sink_sensor.T_sensor, T_cold_sink) annotation (Line(points={{32,10},
+          {32,14},{30,14},{30,22}},     color={0,0,127}));
+  connect(P_cold_sink_sensor.P_sensor, P_cold_sink)
+    annotation (Line(points={{58,10},{56,10},{56,24}}, color={0,0,127}));
+  connect(reheater_sideDrainsInlet.Kfr_cold, Kfr_cold)
+    annotation (Line(points={{-22,4},{-36,4},{-36,16}}, color={0,0,127}));
+  connect(reheater_sideDrainsInlet.Kth_subc, Kth_subc)
+    annotation (Line(points={{-12,10},{-12,30},{-18,30}}, color={0,0,127}));
+  connect(reheater_sideDrainsInlet.Kth_cond, Kth_cond) annotation (Line(points={
+          {-11.8,-10},{-12,-10},{-12,-18},{-30,-18}}, color={0,0,127}));
+  connect(reheater_sideDrainsInlet.C_hot_out, T_drains_sensor.C_in) annotation
+    (Line(points={{-4,-8},{-4,-14},{0,-14},{0,-20}}, color={28,108,200}));
+  connect(reheater_sideDrainsInlet.C_hot_in, Extr_source.C_out) annotation (
+      Line(points={{-4,8},{-4,16},{0,16},{0,25}}, color={28,108,200}));
+  connect(reheater_sideDrainsInlet.C_cold_in, cold_source.C_out)
+    annotation (Line(points={{-20.2,0},{-43,0}}, color={28,108,200}));
+  connect(Drains_source.C_out, reheater_sideDrainsInlet.C_drains_in)
+    annotation (Line(points={{51,-28},{34,-28},{34,-14},{5,-14},{5,-8}},
+        color={28,108,200}));
+  connect(T_cold_sink_sensor.C_in, reheater_sideDrainsInlet.C_cold_out)
+    annotation (Line(points={{22,0},{12,0}}, color={28,108,200}));
+end Reheater_reverse_sideDrainsInlet;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_direct.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_direct.mo
@@ -10,45 +10,70 @@ model Superheater_direct
   input Real h_cold_steam(start=2.75e6) "J/kg"; // slightly humid cold steam
   input Real h_hot_steam(start=2.8e6) "J/kg"; // slightly superheated hot steam
 
-  // Parameters
-  parameter Utilities.Units.Area S=100;
-  parameter Utilities.Units.HeatExchangeCoefficient Kth=7e3;
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=0;
-  parameter Utilities.Units.FrictionCoefficient Kfr_hot=500;
-                                                     // About 1 bar of pressure loss in the reheater
-  parameter Utilities.Units.PositiveMassFlowRate Q_vent=1;
-
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_steam_source annotation (Placement(transformation(extent={{-68,-10},{-48,10}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink drains_sink annotation (Placement(transformation(extent={{48,-10},{68,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_steam_source annotation (Placement(transformation(extent={{-72,-10},
+            {-52,10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink drains_sink annotation (Placement(transformation(extent={{70,-10},{90,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_steam_source annotation (Placement(transformation(extent={{-42,-50},{-22,-30}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink superheated_steam_sink annotation (Placement(transformation(extent={{16,30},{36,50}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Superheater superheater annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink vent_sink annotation (Placement(transformation(extent={{48,-30},{68,-10}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink superheated_steam_sink annotation (Placement(transformation(extent={{16,70},
+            {36,90}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Superheater superheater(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink vent_sink annotation (Placement(transformation(extent={{70,-30},{90,-10}})));
+  Utilities.Interfaces.RealOutput Kth_sup annotation (Placement(transformation(
+          extent={{10,20},{18,28}}),   iconTransformation(extent={{-192,-82},{-172,
+            -62}})));
+  Utilities.Interfaces.RealOutput Kth_evap annotation (Placement(transformation(
+          extent={{-22,22},{-14,30}}),
+                                     iconTransformation(extent={{-192,-82},{-172,
+            -62}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_superheated_steam_sensor(
+    sensor_function="Calibration",
+    causality="Kth_sup",
+    T_start=224,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={0,54})));
+  Utilities.Interfaces.RealOutput T_superheated_steam annotation (Placement(
+        transformation(extent={{-30,50},{-22,58}}), iconTransformation(extent={
+            {-192,-82},{-172,-62}})));
 equation
 
   // Boundary conditions
   hot_steam_source.P_out = P_hot_steam*1e5;
   hot_steam_source.h_out = h_hot_steam;
-
   cold_steam_source.P_out = P_cold_steam*1e5;
   cold_steam_source.h_out = h_cold_steam;
   cold_steam_source.Q_out = - Q_cold;
 
-  // Component parameters
-  superheater.Kth = Kth;
-  superheater.S = S;
-  superheater.Kfr_cold=Kfr_cold;
-  superheater.Kfr_hot=Kfr_hot;
-  superheater.Q_vent = Q_vent;
+  // Specifications, for if "input_specs" is set to true
+  superheater.S_evap = 10;
+  superheater.S_sup = 100;
+  superheater.Q_vent = 1;
 
-  connect(superheater.C_cold_out, superheated_steam_sink.C_in) annotation (Line(
-        points={{0,8},{0,8},{0,40},{21,40}},    color={28,108,200}));
-  connect(superheater.C_hot_out, drains_sink.C_in)
-    annotation (Line(points={{16,0},{53,0}}, color={28,108,200}));
+  // Calibrated parameters
+  Kth_sup = 7e3;
+
   connect(cold_steam_source.C_out,superheater. C_cold_in)
     annotation (Line(points={{-27,-40},{0,-40},{0,-8}}, color={28,108,200}));
-  connect(hot_steam_source.C_out,superheater. C_hot_in) annotation (Line(points={{-53,0},{-34.5,0},{-34.5,0},{-16,0}},
-                                                    color={28,108,200}));
-  connect(vent_sink.C_in, superheater.C_vent) annotation (Line(points={{53,-20},
-          {16,-20},{16,-7.8}}, color={28,108,200}));
+  connect(hot_steam_source.C_out,superheater. C_hot_in) annotation (Line(points={{-57,0},
+          {-16,0}},                                 color={28,108,200}));
+  connect(vent_sink.C_in, superheater.C_vent) annotation (Line(points={{75,-20},
+          {20,-20},{20,-7.8},{16,-7.8}},
+                               color={28,108,200}));
+  connect(drains_sink.C_in, superheater.C_hot_out)
+    annotation (Line(points={{75,0},{16,0}}, color={28,108,200}));
+  connect(superheater.Kth_evap, Kth_evap)
+    annotation (Line(points={{-8,10},{-8,26},{-18,26}},
+                                                     color={0,0,127}));
+  connect(T_superheated_steam_sensor.C_in, superheater.C_cold_out)
+    annotation (Line(points={{0,44},{0,8}}, color={28,108,200}));
+  connect(T_superheated_steam_sensor.C_out, superheated_steam_sink.C_in)
+    annotation (Line(points={{0,64},{0,80},{21,80}}, color={28,108,200}));
+  connect(superheater.Kth_sup, Kth_sup)
+    annotation (Line(points={{6,10},{6,24},{14,24}}, color={0,0,127}));
+  connect(T_superheated_steam_sensor.T_sensor, T_superheated_steam)
+    annotation (Line(points={{-10,54},{-26,54}}, color={0,0,127}));
 end Superheater_direct;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_faulty.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_faulty.mo
@@ -1,21 +1,16 @@
 within MetroscopeModelingLibrary.Tests.WaterSteam.HeatExchangers;
 model Superheater_faulty
-  extends Superheater_direct(
+  extends Superheater_direct     (
       superheater(faulty = true));
 
-  Real Fault_fouling(start=0);
-  Real Fault_closed_vent(start=0);
-  Real Fault_tube_rupture_leak(start=0);
+  input Real Fault_fouling_or_drains_flooding(start=0); // Modeled as fouling, but represents either fouling drains flooding in on the hot-side
+  input Real Fault_closed_vent(start=0);
+  input Real Fault_tube_rupture_leak(start=0);
 
 equation
 
-  // Failure input
-  Fault_fouling = 0 + 10*time;
-  Fault_closed_vent = 0 + 100*time; // Fully closed vent at end of simulation
-  Fault_tube_rupture_leak = 5*time;
-
   // Failure definition
-  superheater.fouling = Fault_fouling;
+  superheater.fouling_or_drains_flooding = Fault_fouling_or_drains_flooding + 10*time; // Study fouling/drains flooding fault
   superheater.closed_vent = Fault_closed_vent;
   superheater.tube_rupture_leak = Fault_tube_rupture_leak;
 

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_reverse.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/HeatExchangers/Superheater_reverse.mo
@@ -10,34 +10,35 @@ model Superheater_reverse
   input Real h_cold_steam(start=2.75e6) "J/kg"; // slightly humid cold steam
   input Real h_hot_steam(start=2.8e6) "J/kg"; // slightly superheated hot steam
 
-  // Parameters
-  parameter Utilities.Units.Area S=100;
-
-  parameter Utilities.Units.FrictionCoefficient Kfr_cold=0;
-
-  parameter Utilities.Units.PositiveMassFlowRate Q_vent=1;
-
-  // Inputs for calibration
-  input Real superheated_steam_temperature(start=224, min=0, nominal = 200) "degC";
-  input Real drains_pressure(start=59.5, min=0, nominal = 100e5) "barA";
-
-  // Calibrated parameters
-  output Utilities.Units.HeatExchangeCoefficient Kth;
-  output Utilities.Units.FrictionCoefficient Kfr_hot;
-
-  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_steam_source annotation (Placement(transformation(extent={{-70,-2},{-50,18}})));
+  .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source hot_steam_source annotation (Placement(transformation(extent={{-72,-10},
+            {-52,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink drains_sink annotation (Placement(transformation(extent={{70,-10},{90,10}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source cold_steam_source annotation (Placement(transformation(extent={{-42,-50},{-22,-30}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink superheated_steam_sink annotation (Placement(transformation(extent={{16,70},
             {36,90}})));
-  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Superheater superheater annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
+  .MetroscopeModelingLibrary.WaterSteam.HeatExchangers.Superheater superheater(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-16,-8},{16,8}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink vent_sink annotation (Placement(transformation(extent={{70,-30},{90,-10}})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.TemperatureSensor superheated_steam_temperature_sensor annotation (Placement(transformation(
+  Utilities.Interfaces.RealOutput Kth_sup annotation (Placement(transformation(
+          extent={{10,20},{18,28}}),   iconTransformation(extent={{-192,-82},{-172,
+            -62}})));
+  Utilities.Interfaces.RealOutput Kth_evap annotation (Placement(transformation(
+          extent={{-22,22},{-14,30}}),
+                                     iconTransformation(extent={{-192,-82},{-172,
+            -62}})));
+  Sensors_Control.WaterSteam.TemperatureSensor T_superheated_steam_sensor(
+    sensor_function="Calibration",
+    causality="Kth_sup",
+    T_start=224,
+    signal_unit="degC",
+    display_unit="degC") annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={0,62})));
-  MetroscopeModelingLibrary.Sensors.WaterSteam.PressureSensor drains_pressure_sensor(Q_0=50)
-                                                                                     annotation (Placement(transformation(extent={{38,-10},{58,10}})));
+        origin={0,54})));
+  Utilities.Interfaces.CalibrationInput T_superheated_steam annotation (
+      Placement(transformation(extent={{-30,50},{-22,58}}), iconTransformation(
+          extent={{-200,-14},{-160,26}})));
 equation
 
   // Boundary conditions
@@ -47,34 +48,29 @@ equation
   cold_steam_source.h_out = h_cold_steam;
   cold_steam_source.Q_out = - Q_cold;
 
-  // Component parameters
-  superheater.S = S;
-  superheater.Kfr_cold=Kfr_cold;
-  superheater.Q_vent = Q_vent;
-
-  // Inputs for calibration
-  drains_pressure_sensor.P_barA = drains_pressure;
-  superheated_steam_temperature_sensor.T_degC = superheated_steam_temperature;
-
-  // Calibrated parameters
-  superheater.Kth = Kth;
-  superheater.Kfr_hot=Kfr_hot;
+  // Specifications, for if "input_specs" is set to true
+  superheater.S_evap = 10;
+  superheater.S_sup = 100;
+  superheater.Q_vent = 1;
 
   connect(cold_steam_source.C_out,superheater. C_cold_in)
     annotation (Line(points={{-27,-40},{0,-40},{0,-8}}, color={28,108,200}));
-  connect(hot_steam_source.C_out,superheater. C_hot_in) annotation (Line(points={{-55,8},{-34.5,8},{-34.5,0},{-16,0}},
-                                                    color={28,108,200}));
+  connect(hot_steam_source.C_out,superheater. C_hot_in) annotation (Line(points={{-57,0},
+          {-16,0}},                                 color={28,108,200}));
   connect(vent_sink.C_in, superheater.C_vent) annotation (Line(points={{75,-20},
           {20,-20},{20,-7.8},{16,-7.8}},
                                color={28,108,200}));
-  connect(superheater.C_cold_out, superheated_steam_temperature_sensor.C_in)
-    annotation (Line(points={{0,8},{0,52}},
-        color={28,108,200}));
-  connect(superheated_steam_temperature_sensor.C_out, superheated_steam_sink.C_in)
-    annotation (Line(points={{0,72},{0,80},{21,80}},                     color={
-          28,108,200}));
-  connect(superheater.C_hot_out, drains_pressure_sensor.C_in)
-    annotation (Line(points={{16,0},{38,0}}, color={28,108,200}));
-  connect(drains_pressure_sensor.C_out, drains_sink.C_in)
-    annotation (Line(points={{58,0},{75,0}}, color={28,108,200}));
+  connect(drains_sink.C_in, superheater.C_hot_out)
+    annotation (Line(points={{75,0},{16,0}}, color={28,108,200}));
+  connect(superheater.Kth_evap, Kth_evap)
+    annotation (Line(points={{-8,10},{-8,26},{-18,26}},
+                                                     color={0,0,127}));
+  connect(T_superheated_steam_sensor.C_in, superheater.C_cold_out)
+    annotation (Line(points={{0,44},{0,8}}, color={28,108,200}));
+  connect(T_superheated_steam_sensor.C_out, superheated_steam_sink.C_in)
+    annotation (Line(points={{0,64},{0,80},{21,80}}, color={28,108,200}));
+  connect(T_superheated_steam_sensor.T_sensor, T_superheated_steam)
+    annotation (Line(points={{-10,54},{-26,54}}, color={0,0,127}));
+  connect(superheater.Kth_sup, Kth_sup)
+    annotation (Line(points={{6,10},{6,24},{14,24}}, color={0,0,127}));
 end Superheater_reverse;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/Volumes/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/Volumes/SteamDryer.mo
@@ -2,32 +2,43 @@ within MetroscopeModelingLibrary.Tests.WaterSteam.Volumes;
 model SteamDryer
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
+  // To input either efficiency or x_steam_out, put:
+  // --> steamDryer (input_specifications = true);
+
   // Boundary Conditions
   input Utilities.Units.Pressure P_source(start=10e5) "Pa";
   input Utilities.Units.NegativeMassFlowRate Q_source(start=-500) "kg/s";
   input Utilities.Units.SpecificEnthalpy h_source(start=2e6) "J/kg";
 
   // Component parameters
-  parameter Real x_steam_out = 0.9;
+  output Real x_steam_in;
+  output Real x_steam_out;
 
-  .MetroscopeModelingLibrary.WaterSteam.Volumes.SteamDryer steamDryer annotation (Placement(transformation(extent={{-32,-26},{28,34}})));
+  .MetroscopeModelingLibrary.WaterSteam.Volumes.SteamDryer steamDryer(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-32,-26},{28,34}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source source annotation (Placement(transformation(extent={{-80,2},{-60,22}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink steam_sink annotation (Placement(transformation(extent={{56,2},{76,22}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink liquid_sink annotation (Placement(transformation(extent={{56,-50},{76,-30}})));
+
 equation
 
   // Boundary conditions
   source.P_out = P_source;
   source.Q_out = Q_source;
   source.h_out = h_source;
+  steamDryer.x_steam_in = x_steam_in; // A consequence of the boundary conditions
 
-  // Component parameters
+  // Specifications, for if "input_specs" is set to true
+  steamDryer.MS_efficiency = 0.99;
+
+  // Output observables
   steamDryer.x_steam_out = x_steam_out;
 
-  connect(steamDryer.C_in, source.C_out) annotation (Line(points={{-32,12.1818},{-32,12},{-65,12}},
-                                            color={28,108,200}));
-  connect(steamDryer.C_hot_steam, steam_sink.C_in) annotation (Line(points={{28,12.1818},{28,12},{61,12}},
-                                                  color={28,108,200}));
+  connect(steamDryer.C_in, source.C_out) annotation (Line(points={{-32,12.1818},
+          {-32,12},{-65,12}},               color={28,108,200}));
+  connect(steamDryer.C_hot_steam, steam_sink.C_in) annotation (Line(points={{28,
+          12.1818},{28,12},{61,12}},              color={28,108,200}));
   connect(steamDryer.C_hot_liquid, liquid_sink.C_in) annotation (Line(points={{28,-9.63636},{28,-8},{52,-8},{52,-40},{61,-40}},
                                                       color={28,108,200}));
 end SteamDryer;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
@@ -163,8 +163,8 @@ equation
 
   // Pressure losses
   cold_side_pipe.Kfr = Kfr_cold;
-  water_height_pipe.delta_z = - water_height; // ** REMOVE, to deal with separately
-  water_height_pipe.DP = water_height_DP; // ** REMOVE, to deal with separately
+  water_height_pipe.delta_z = - water_height;
+  water_height_pipe.DP = water_height_DP;
 
   // Incondensables
   P_incond = P_offset + R * (C_incond + air_intake) * Tsat;  // Ideal gaz law
@@ -182,7 +182,7 @@ equation
   hot_side.h_out = Water.bubbleEnthalpy(Water.setSat_p(Psat));
 
   // Heat Exchange
-  0 = Tsat - T_cold_out - (Tsat - T_cold_in)*exp(Kth*(1-fouling/100)*(S)*((T_cold_in - T_cold_out)/W));
+  0 = Tsat - T_cold_out - (Tsat - T_cold_in)*exp(Kth*(1-fouling/100)*S*((T_cold_in - T_cold_out)/W));
 
   connect(cold_side_pipe.C_out, cold_side.C_in) annotation (Line(
       points={{-60,0},{-24,0}},

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Condenser.mo
@@ -5,8 +5,12 @@ model Condenser
   import MetroscopeModelingLibrary.Utilities.Units;
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
 
-  parameter Inputs.InputHeight water_height=1;
-  parameter Units.Area S = 50000;
+  // New features: option to input area S and water height with input_specifications
+
+  // ** Subcooling **
+  parameter Boolean input_specs = false;
+  Units.Area S;
+  Real water_height;
 
   parameter String QCp_max_side = "cold";
 
@@ -128,6 +132,12 @@ model Condenser
         origin={64,110})));
 equation
 
+  // Subcooling
+  if not input_specs then
+    S = 50000;
+    water_height = 1;
+  end if;
+
   // Failure modes
   if not faulty then
     fouling = 0;
@@ -153,8 +163,8 @@ equation
 
   // Pressure losses
   cold_side_pipe.Kfr = Kfr_cold;
-  water_height_pipe.delta_z = - water_height;
-  water_height_pipe.DP = water_height_DP;
+  water_height_pipe.delta_z = - water_height; // ** REMOVE, to deal with separately
+  water_height_pipe.DP = water_height_DP; // ** REMOVE, to deal with separately
 
   // Incondensables
   P_incond = P_offset + R * (C_incond + air_intake) * Tsat;  // Ideal gaz law
@@ -172,7 +182,7 @@ equation
   hot_side.h_out = Water.bubbleEnthalpy(Water.setSat_p(Psat));
 
   // Heat Exchange
-  0 = Tsat - T_cold_out - (Tsat - T_cold_in)*exp(Kth*(1-fouling/100)*S*((T_cold_in - T_cold_out)/W));
+  0 = Tsat - T_cold_out - (Tsat - T_cold_in)*exp(Kth*(1-fouling/100)*(S)*((T_cold_in - T_cold_out)/W));
 
   connect(cold_side_pipe.C_out, cold_side.C_in) annotation (Line(
       points={{-60,0},{-24,0}},

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/DryReheater.mo
@@ -5,7 +5,10 @@ model DryReheater
   import MetroscopeModelingLibrary.Utilities.Units;
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
 
-  parameter Inputs.InputArea S=100;
+  // New features: option to input area S with input_specs
+
+  parameter Boolean input_specs = false;
+  Units.Area S;
 
   Units.SpecificEnthalpy h_vap_sat(start=h_vap_sat_0);
   Units.SpecificEnthalpy h_liq_sat(start=h_liq_sat_0);
@@ -36,6 +39,7 @@ model DryReheater
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
   Units.MassFlowRate partition_plate_leak;  // Separating plate leak
   Units.MassFlowRate tube_rupture_leak; // Tube rupture leak : cold water leaks and mixes with the condensed steam
+  Real hot_side_partition_plate_leak;
 
   // Initialization parameters
   parameter Units.MassFlowRate Q_cold_0 = 500;
@@ -93,8 +97,12 @@ model DryReheater
     h_in_0=h_cold_in_0,
     h_out_0=h_cold_out_0,                        Q_0=Q_cold_0,
     P_0=P_cold_out_0)                                          annotation (Placement(transformation(extent={{-82,-58},{-34,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
-                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_condensing(
+    config=HX_config,
+    Q_hot_0=Q_hot_0,
+    Q_cold_0=Q_cold_0,
+    T_hot_in_0=T_hot_in_0,
+    T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={-60,0})));
@@ -119,16 +127,26 @@ model DryReheater
         extent={{-20,-20},{20,20}},
         rotation=90,
         origin={-80,100})));
+  Pipes.Leak hot_side_partition_plate annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-2,-8})));
 protected
   parameter Units.SpecificEnthalpy h_vap_sat_0 = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_hot_out_0));
   parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_hot_out_0));
 equation
+
+  // Input specifications
+  if not input_specs then
+    S = 100;
+  end if;
 
   // Failure modes
   if not faulty then
     fouling = 0;
     partition_plate_leak = 0;
     tube_rupture_leak = 0;
+    hot_side_partition_plate_leak = 0;
   end if;
 
   // Definitions
@@ -186,6 +204,7 @@ equation
   // Internal leaks
   partition_plate.Q = 1e-5 + partition_plate_leak;
   tube_rupture.Q = 1e-5 + tube_rupture_leak;
+  hot_side_partition_plate.Q = 1e-5 + hot_side_partition_plate_leak;
 
   // Total power
   W = W_deheat + W_cond;
@@ -236,6 +255,11 @@ equation
       points={{94,19},{120,19},{120,60},{0,60},{0,80}},
       color={255,0,0},
       thickness=1));
+  connect(hot_side_partition_plate.C_in, hot_side_deheating.C_out) annotation (
+      Line(points={{-2,2},{-4,2},{-4,19},{48,19}}, color={28,108,200}));
+  connect(hot_side_partition_plate.C_out, final_mix_hot.C_in) annotation (Line(
+        points={{-2,-18},{-4,-18},{-4,-46},{-68,-46},{-68,-66},{-64,-66}},
+        color={28,108,200}));
   annotation (Icon(coordinateSystem(extent={{-160,-80},{160,80}}),
                    graphics={
         Polygon(

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -73,7 +73,8 @@ model LiqLiqHX
         rotation=180,
         origin={-1,21})));
   BaseClasses.IsoPFlowModel cold_side(Q_0=Q_cold_0, P_0 = P_cold_out_0, h_in_0 = h_cold_in_0, h_out_0 = h_cold_out_0, T_in_0 = T_cold_in_0, T_out_0 = T_cold_out_0) annotation (Placement(transformation(extent={{-26,-58},{22,-10}})));
-  Power.HeatExchange.NTUHeatExchange_v2_epsilonErrors HX(config=HX_config, QCp_max_side = QCp_max_side) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX(config=HX_config, QCp_max_side=
+        QCp_max_side) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={0,-6})));

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/LiqLiqHX.mo
@@ -4,10 +4,13 @@ model LiqLiqHX
   import MetroscopeModelingLibrary.Utilities.Units;
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
 
+  // New features: option to input S with input_specifications, and tube rupture leak. Default QCp max side is unknown, and HX_config default should be countercurrent but not changing so as to not mess up past moedls
 
+  // Specifications
+  parameter Boolean input_specs = false;
+  Units.Area S;
 
-  parameter Inputs.InputArea S=100;
-  parameter String QCp_max_side = "cold";
+  parameter String QCp_max_side = "unknown";
   parameter String HX_config = "shell_and_tubes_two_passes"; // Valid for U-shaped tubes. Otherwise use "monophasic_cross_current"
 
   Units.Power W;
@@ -27,6 +30,7 @@ model LiqLiqHX
   // Failure modes
   parameter Boolean faulty = false;
   Units.Percentage fouling(min = 0, max=100); // Fouling percentage
+  Real tube_rupture_leak;
 
   // Initialization parameters
   parameter Units.MassFlowRate Q_cold_0 = 500;
@@ -69,11 +73,11 @@ model LiqLiqHX
         rotation=180,
         origin={-1,21})));
   BaseClasses.IsoPFlowModel cold_side(Q_0=Q_cold_0, P_0 = P_cold_out_0, h_in_0 = h_cold_in_0, h_out_0 = h_cold_out_0, T_in_0 = T_cold_in_0, T_out_0 = T_cold_out_0) annotation (Placement(transformation(extent={{-26,-58},{22,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX(config=HX_config, QCp_max_side = QCp_max_side) annotation (Placement(
-        transformation(
+  Power.HeatExchange.NTUHeatExchange_v2_epsilonErrors HX(config=HX_config, QCp_max_side = QCp_max_side) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={0,-6})));
+
   Utilities.Interfaces.GenericReal Kth annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
         rotation=270,
@@ -95,11 +99,20 @@ model LiqLiqHX
         extent={{-20,-20},{20,20}},
         rotation=90,
         origin={48,100})));
+  Pipes.Leak tube_rupture annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-30,-10})));
 equation
+
+  if not input_specs then
+    S = 100;
+  end if;
 
   // Failure modes
   if not faulty then
     fouling = 0;
+    tube_rupture_leak = 0;
   end if;
 
   // Definitions
@@ -113,7 +126,6 @@ equation
 
   // Energy balance
   hot_side.W + cold_side.W = 0;
-
 
   // Power Exchange
   HX.W = W;
@@ -133,6 +145,9 @@ equation
   pinch = min(TTD, DCA);
   assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
   assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
+
+  // Failure modes
+  tube_rupture.Q = 1e-5 + tube_rupture_leak;
 
   connect(cold_side_pipe.C_out, cold_side.C_in) annotation (Line(
       points={{-120,0},{-52,0},{-52,-34},{-26,-34}},
@@ -158,8 +173,15 @@ equation
       points={{-24,21},{-30,21},{-30,20},{-40,20},{-40,-60},{0,-60},{0,-80}},
       color={238,46,47},
       thickness=1));
-  connect(cold_side_pipe.Kfr, Kfr_cold) annotation (Line(points={{-130,4},{-130,32},{-128,32},{-128,56}}, color={0,0,127}));
-  connect(hot_side_pipe.Kfr, Kfr_hot) annotation (Line(points={{4,52},{24,52},{24,72},{50,72}}, color={0,0,127}));
+  connect(Kfr_hot, hot_side_pipe.Kfr) annotation (Line(points={{50,72},{16,72},{
+          16,52},{4,52}}, color={0,0,127}));
+  connect(Kfr_cold, cold_side_pipe.Kfr) annotation (Line(points={{-128,56},{-128,
+          14},{-130,14},{-130,4}}, color={0,0,127}));
+  connect(tube_rupture.C_out, C_hot_out) annotation (Line(points={{-30,-20},{-30,
+          -26},{-34,-26},{-34,-66},{0,-66},{0,-80}},
+                                          color={28,108,200}));
+  connect(tube_rupture.C_in, cold_side_pipe.C_out) annotation (Line(points={{-30,
+          0},{-32,0},{-32,8},{-100,8},{-100,0},{-120,0}}, color={28,108,200}));
     annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-160,-80},
             {160,80}}),      graphics={
         Polygon(

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater.mo
@@ -2,12 +2,16 @@ within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
 model Reheater
   package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
 
+  // New features: option of inputting water level, heater height and total heat exchange area; changed location of tube rupture leak; added hot-side partition plate leak
+
   import MetroscopeModelingLibrary.Utilities.Units;
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
 
   Units.Power W;
-  parameter Inputs.InputArea S=100;
+  Inputs.InputArea S;
   parameter Inputs.InputFraction level(min=0, max=1)=0.3;
+
+  parameter Boolean input_specs = false;
 
   // Deheating
   Units.Power W_deheat;
@@ -25,8 +29,8 @@ model Reheater
   Units.Temperature Tsat;
 
   parameter String HX_config_condensing="condenser";
-  parameter String HX_config_subcooling="monophasic_cross_current"; // In subcooling zone, there is only the bottom part of the U-shaped tubes, so it is considered as cross current.
-  parameter String QCp_max_side_subcooling = "cold";
+  parameter String HX_config_subcooling="monophasic_counter_current"; // In subcooling zone, there is only the bottom part of the U-shaped tubes, so it is considered as cross current.
+  parameter String QCp_max_side_subcooling = "unknown";
 
   Units.PositiveMassFlowRate Q_cold_in(start=Q_cold_0, nominal=Q_cold_0);
   Units.PositiveMassFlowRate Q_hot_in(start=Q_hot_0, nominal=Q_hot_0);
@@ -49,6 +53,7 @@ model Reheater
   Units.Fraction water_level_rise;  // Water level rise (can be negative)
   Units.MassFlowRate partition_plate_leak;  // Separating plate leak
   Units.MassFlowRate tube_rupture_leak; // Tube rupture leak : cold water leaks and mixes with the condensed steam
+  Real hot_side_partition_plate_leak;
 
   // Initialization parameters
   parameter Units.PositiveMassFlowRate Q_cold_0=500;
@@ -112,8 +117,12 @@ model Reheater
     h_in_0=0.5*(h_cold_in_0 + h_cold_out_0),
     h_out_0=h_cold_out_0,                        Q_0=Q_cold_0,
     P_0=P_cold_out_0)                                          annotation (Placement(transformation(extent={{0,-58},{48,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config_condensing, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
-                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_condensing(
+    config=HX_config_condensing,
+    Q_hot_0=Q_hot_0,
+    Q_cold_0=Q_cold_0,
+    T_hot_in_0=T_hot_in_0,
+    T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={24,-10})));
@@ -132,9 +141,13 @@ model Reheater
     h_in_0=h_cold_in_0,
     h_out_0=0.5*(h_cold_in_0 + h_cold_out_0),    Q_0=Q_cold_0,
     P_0=P_cold_out_0)                                          annotation (Placement(transformation(extent={{-78,-58},{-30,-10}})));
-  Power.HeatExchange.NTUHeatExchange HX_subcooling(config=HX_config_subcooling, QCp_max_side=QCp_max_side_subcooling, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
-                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0)
-    annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_subcooling(
+    config=HX_config_subcooling,
+    QCp_max_side=QCp_max_side_subcooling,
+    Q_hot_0=Q_hot_0,
+    Q_cold_0=Q_cold_0,
+    T_hot_in_0=T_hot_in_0,
+    T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={-54,-10})));
@@ -143,7 +156,10 @@ model Reheater
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={144,-18})));
-  Pipes.Leak tube_rupture annotation (Placement(transformation(extent={{-94,-24},{-74,-4}})));
+  Pipes.Leak tube_rupture annotation (Placement(transformation(extent={{-10,-10},
+            {10,10}},
+        rotation=90,
+        origin={-30,-4})));
   BaseClasses.IsoPHFlowModel final_mix_hot annotation (Placement(transformation(extent={{-60,-70},
             {-40,-50}})));
 protected
@@ -155,7 +171,7 @@ public
         transformation(
         extent={{-20,-20},{20,20}},
         rotation=270,
-        origin={-130,50}), iconTransformation(extent={{-20,-20},{20,20}},
+        origin={-192,38}), iconTransformation(extent={{-20,-20},{20,20}},
         rotation=180,
         origin={-180,40})));
 public
@@ -163,7 +179,7 @@ public
         transformation(
         extent={{-20,-20},{20,20}},
         rotation=270,
-        origin={-110,80}), iconTransformation(
+        origin={-70,80}),  iconTransformation(
         extent={{-20,-20},{20,20}},
         rotation=270,
         origin={-78,-100})));
@@ -176,6 +192,10 @@ public
         extent={{-20,-20},{20,20}},
         rotation=90,
         origin={-80,100})));
+  Pipes.Leak hot_side_partition_plate annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-16,-8})));
 equation
 
   // Failure modes
@@ -184,6 +204,11 @@ equation
     water_level_rise = 0;
     partition_plate_leak = 0;
     tube_rupture_leak = 0;
+    hot_side_partition_plate_leak = 0;
+  end if;
+
+  if not input_specs then
+    S = 100;
   end if;
 
   // Definitions
@@ -263,6 +288,7 @@ equation
   // Internal leaks
   partition_plate.Q = 1e-5 + partition_plate_leak;
   tube_rupture.Q = 1e-5 + tube_rupture_leak;
+  hot_side_partition_plate.Q = 1e-5 + hot_side_partition_plate_leak;
 
   connect(cold_side_pipe.C_in, C_cold_in) annotation (Line(
       points={{-140,0},{-162,0}},
@@ -300,7 +326,6 @@ equation
 
   connect(partition_plate.C_out, final_mix_cold.C_in) annotation (Line(points={{-90,-68},{144,-68},{144,-28}}, color={217,67,180}));
 
-  connect(tube_rupture.C_in, cold_side_pipe.C_out) annotation (Line(points={{-94,-14},{-114,-14},{-114,0},{-120,0}}, color={217,67,180}));
   connect(cold_side_subcooling.C_in, cold_side_pipe.C_out) annotation (Line(
       points={{-78,-34},{-114,-34},{-114,0},{-120,0}},
       color={28,108,200},
@@ -308,18 +333,26 @@ equation
   connect(final_mix_hot.C_out, C_hot_out) annotation (Line(points={{-40,-60},{0,
           -60},{0,-80}},                                                                       color={238,46,47},
       thickness=1));
-  connect(tube_rupture.C_out, final_mix_hot.C_in) annotation (Line(points={{-74,-14},
-          {-66,-14},{-66,-6},{-102,-6},{-102,-60},{-60,-60}},                                                                            color={217,67,180}));
   connect(hot_side_subcooling.C_out, final_mix_hot.C_in) annotation (Line(
       points={{-91,20},{-100,20},{-100,-60},{-60,-60}},
       color={255,0,0},
       thickness=1));
   connect(cold_side_pipe.Kfr, Kfr_cold)
-    annotation (Line(points={{-130,4},{-130,50}}, color={0,0,127}));
+    annotation (Line(points={{-130,4},{-130,38},{-192,38}},
+                                                  color={0,0,127}));
   connect(hot_side_deheating.C_in, C_hot_in) annotation (Line(
       points={{123,20},{140,20},{140,40},{0,40},{0,80}},
       color={255,0,0},
       thickness=1));
+  connect(hot_side_partition_plate.C_in, C_hot_in) annotation (Line(points={{-16,
+          2},{-16,54},{0,54},{0,80}}, color={28,108,200}));
+  connect(hot_side_partition_plate.C_out, final_mix_hot.C_in) annotation (Line(
+        points={{-16,-18},{-16,-50},{-72,-50},{-72,-60},{-60,-60}}, color={28,108,
+          200}));
+  connect(cold_side_subcooling.C_out, tube_rupture.C_in) annotation (Line(
+        points={{-30,-34},{-30,-34},{-30,-14}}, color={28,108,200}));
+  connect(tube_rupture.C_out, hot_side_subcooling.C_in)
+    annotation (Line(points={{-30,6},{-30,20},{-45,20}}, color={28,108,200}));
     annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-160,-80},
             {160,80}}),      graphics={
         Polygon(

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater_sideDrainsInlet.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Reheater_sideDrainsInlet.mo
@@ -1,0 +1,600 @@
+within MetroscopeModelingLibrary.WaterSteam.HeatExchangers;
+model Reheater_sideDrainsInlet
+  package WaterSteamMedium = MetroscopeModelingLibrary.Utilities.Media.WaterSteamMedium;
+
+  import MetroscopeModelingLibrary.Utilities.Units;
+  import MetroscopeModelingLibrary.Utilities.Units.Inputs;
+
+  Units.Power W;
+  Inputs.InputArea S;
+  parameter Inputs.InputFraction level(min=0, max=1)=0.3;
+
+  parameter Boolean input_specs = false;
+
+  // Deheating
+  Units.Power W_deheat;
+
+  // Condensation
+  Units.Area S_cond;
+  Units.Power W_cond;
+
+  // Subcooling
+  Units.Area S_subc;
+  Units.Power W_subc;
+
+  Units.SpecificEnthalpy h_vap_sat(start=h_vap_sat_0);
+  Units.SpecificEnthalpy h_liq_sat(start=h_liq_sat_0);
+  Units.Temperature Tsat;
+
+  parameter String HX_config_condensing="condenser";
+  parameter String HX_config_subcooling="monophasic_cross_current"; // In subcooling zone, there is only the bottom part of the U-shaped tubes, so it is considered as cross current.
+  parameter String QCp_max_side_subcooling = "cold";
+
+  Units.PositiveMassFlowRate Q_cold_in(start=Q_cold_0, nominal=Q_cold_0);
+  Units.PositiveMassFlowRate Q_hot_in(start=Q_hot_0, nominal=Q_hot_0);
+  Units.NegativeMassFlowRate Q_cold_out(start=-Q_cold_0, nominal=-Q_cold_0); // Should be equal to Q_cold_in if no internal leaks
+  Units.NegativeMassFlowRate Q_hot_out(start=-Q_hot_0, nominal=-Q_hot_0); // Should be equal to Q_hot_in if no internal leaks
+  Units.Temperature T_cold_in(start=T_cold_in_0);
+  Units.Temperature T_cold_out(start=T_cold_out_0);
+  Units.Temperature T_hot_in(start=T_hot_in_0);
+  Units.Temperature T_hot_out(start=T_hot_out_0);
+
+  // Indicators
+  Units.DifferentialTemperature FTR(start=T_cold_out_0-T_cold_in_0) "Feedwater Temperature Rise";
+  Units.DifferentialTemperature TTD(start=T_hot_in_0-T_cold_out_0) "Terminal Temperature Difference";
+  Units.DifferentialTemperature DCA(start=T_hot_out_0-T_cold_in_0) "Drain Cooler Approach";
+  Units.DifferentialTemperature pinch(start=min(T_hot_in_0-T_cold_out_0,T_hot_out_0-T_cold_in_0)) "Lowest temperature difference";
+
+  // Failure modes
+  parameter Boolean faulty = false;
+  Units.Percentage fouling(min = 0, max=100); // Fouling percentage
+  Units.Fraction water_level_rise;  // Water level rise (can be negative)
+  Units.MassFlowRate partition_plate_leak;  // Separating plate leak
+  Units.MassFlowRate tube_rupture_leak; // Tube rupture leak : cold water leaks and mixes with the condensed steam
+  Real hot_side_partition_plate_leak;
+
+  // Initialization parameters
+  parameter Units.PositiveMassFlowRate Q_cold_0=500;
+  parameter Units.PositiveMassFlowRate Q_hot_0=50;
+  parameter Units.Pressure P_cold_in_0 = 10e5;
+  parameter Units.Pressure P_cold_out_0 = 9e5;
+  parameter Units.Pressure P_hot_in_0 = 11e5;
+  parameter Units.Pressure P_hot_out_0 = 11e5;
+  parameter Units.Temperature T_cold_in_0 = 273.15 + 50;
+  parameter Units.Temperature T_cold_out_0 = 273.15 + 100;
+  parameter Units.Temperature T_hot_in_0 = 273.15 + 200;
+  parameter Units.Temperature T_hot_out_0 = 273.15 + 150;
+  parameter Units.SpecificEnthalpy h_cold_in_0 = 2e5;
+  parameter Units.SpecificEnthalpy h_cold_out_0 = 7e5;
+  parameter Units.SpecificEnthalpy h_hot_in_0 = 2.9e6;
+  parameter Units.SpecificEnthalpy h_hot_out_0 = 6e5;
+
+  Connectors.Inlet C_cold_in(Q(start=Q_cold_0), P(start=P_cold_in_0))
+                                                annotation (Placement(transformation(extent={{-172,-10},{-152,10}}), iconTransformation(extent={{-172,-10},{-152,10}})));
+  Connectors.Inlet C_hot_in(Q(start=Q_hot_0), P(start=P_hot_in_0))
+                                              annotation (Placement(transformation(extent={{-10,70},{10,90}}), iconTransformation(extent={{-10,70},{10,90}})));
+  Connectors.Outlet C_hot_out(Q(start=-Q_hot_0),
+    P(start=P_hot_out_0),
+    h_outflow(start=h_hot_out_0))                annotation (Placement(transformation(extent={{-10,-90},{10,-70}}), iconTransformation(extent={{-10,-90},{10,-70}})));
+  Connectors.Outlet C_cold_out(Q(start=-Q_cold_0), P(start=P_cold_out_0),
+    h_outflow(start=h_cold_out_0))                 annotation (Placement(transformation(extent={{150,-10},{170,10}}), iconTransformation(extent={{150,-10},{170,10}})));
+
+  Pipes.FrictionPipe cold_side_pipe(
+    P_in_0=P_cold_in_0,
+    P_out_0=P_cold_out_0,
+    Q_0=Q_cold_0,
+    T_0=T_cold_in_0,
+    h_0=h_cold_in_0) annotation (Placement(transformation(extent={{-140,-10},{-120,10}})));
+  BaseClasses.IsoPFlowModel hot_side_deheating(
+    T_in_0=T_hot_in_0,
+    T_out_0=T_hot_in_0,
+    h_in_0=h_hot_in_0,
+    h_out_0=h_vap_sat_0,                       Q_0=Q_hot_0,
+    P_0=P_hot_out_0)                                        annotation (Placement(transformation(
+        extent={{-23,-23},{23,23}},
+        rotation=180,
+        origin={100,20})));
+  BaseClasses.IsoPFlowModel cold_side_deheating(
+    T_in_0=T_cold_out_0,
+    T_out_0=T_cold_out_0,
+    h_in_0=h_cold_out_0,
+    h_out_0=h_cold_out_0,                       Q_0=Q_cold_0,
+    P_0=P_cold_out_0)                                         annotation (Placement(transformation(extent={{80,-58},{128,-10}})));
+  BaseClasses.IsoPFlowModel hot_side_condensing(
+    T_in_0=T_hot_in_0,
+    T_out_0=T_hot_in_0,
+    h_in_0=h_vap_sat_0,
+    h_out_0=h_liq_sat_0,                        Q_0=Q_hot_0,
+    P_0=P_hot_out_0)                                         annotation (Placement(transformation(
+        extent={{-23,-23},{23,23}},
+        rotation=180,
+        origin={20,20})));
+  BaseClasses.IsoPFlowModel cold_side_condensing(
+    T_in_0=0.5*(T_cold_in_0 + T_cold_out_0),
+    T_out_0=T_cold_out_0,
+    h_in_0=0.5*(h_cold_in_0 + h_cold_out_0),
+    h_out_0=h_cold_out_0,                        Q_0=Q_cold_0,
+    P_0=P_cold_out_0)                                          annotation (Placement(transformation(extent={{0,-58},{48,-10}})));
+  Power.HeatExchange.NTUHeatExchange HX_condensing(
+    config=HX_config_condensing,
+    Q_hot_0=Q_hot_0,
+    Q_cold_0=Q_cold_0,
+    T_hot_in_0=T_hot_in_0,
+    T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={24,-10})));
+  BaseClasses.IsoPFlowModel hot_side_subcooling(
+    T_in_0=T_hot_in_0,
+    T_out_0=T_hot_out_0,
+    h_in_0=h_liq_sat_0,
+    h_out_0=h_hot_out_0,                        Q_0=Q_hot_0,
+    P_0=P_hot_out_0)                                         annotation (Placement(transformation(
+        extent={{-23,-23},{23,23}},
+        rotation=180,
+        origin={-68,20})));
+  BaseClasses.IsoPFlowModel cold_side_subcooling(
+    T_in_0=T_cold_in_0,
+    T_out_0=0.5*(T_cold_in_0 + T_cold_out_0),
+    h_in_0=h_cold_in_0,
+    h_out_0=0.5*(h_cold_in_0 + h_cold_out_0),    Q_0=Q_cold_0,
+    P_0=P_cold_out_0)                                          annotation (Placement(transformation(extent={{-78,-58},{-30,-10}})));
+  Power.HeatExchange.NTUHeatExchange HX_subcooling(
+    config=HX_config_subcooling,
+    QCp_max_side=QCp_max_side_subcooling,
+    Q_hot_0=Q_hot_0,
+    Q_cold_0=Q_cold_0,
+    T_hot_in_0=T_hot_in_0,
+    T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={-54,-10})));
+  Pipes.Leak partition_plate annotation (Placement(transformation(extent={{-110,-78},{-90,-58}})));
+  BaseClasses.IsoPHFlowModel final_mix_cold annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={144,-18})));
+  Pipes.Leak tube_rupture annotation (Placement(transformation(extent={{-10,-10},
+            {10,10}},
+        rotation=90,
+        origin={-18,-10})));
+  BaseClasses.IsoPHFlowModel final_mix_hot annotation (Placement(transformation(extent={{-60,-70},
+            {-40,-50}})));
+protected
+  parameter Units.SpecificEnthalpy h_vap_sat_0 = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_hot_out_0));
+  parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_hot_out_0));
+
+public
+  Utilities.Interfaces.GenericReal Kfr_cold annotation (Placement(
+        transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={-192,38}), iconTransformation(extent={{-20,-20},{20,20}},
+        rotation=180,
+        origin={-180,40})));
+public
+  Utilities.Interfaces.GenericReal Kth_cond annotation (Placement(
+        transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={-70,80}),  iconTransformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={-78,-100})));
+public
+  Utilities.Interfaces.GenericReal Kth_subc annotation (Placement(
+        transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={-150,80}), iconTransformation(
+        extent={{-20,-20},{20,20}},
+        rotation=90,
+        origin={-80,100})));
+  Connectors.Inlet C_drains_in(Q(start=Q_hot_0), P(start=P_hot_in_0)) annotation (Placement(transformation(extent={{100,-70},{90,-90}}), iconTransformation(extent={{100,-70},{80,-90}})));
+  Pipes.Leak hot_side_partition_plate annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-6,-10})));
+equation
+
+  // Failure modes
+  if not faulty then
+    fouling = 0;
+    water_level_rise = 0;
+    partition_plate_leak = 0;
+    tube_rupture_leak = 0;
+    hot_side_partition_plate_leak = 0;
+  end if;
+
+  if not input_specs then
+    S = 100;
+  end if;
+
+  // Definitions
+  Q_cold_in = C_cold_in.Q;
+  Q_hot_in = C_hot_in.Q;
+  Q_cold_out = C_cold_out.Q;
+  Q_hot_out = C_hot_out.Q;
+  T_cold_in = cold_side_pipe.T_in;
+  T_cold_out = final_mix_cold.T_out;
+                                // A IsoPHFlowModel is necessary to have a full thermodynamic state with temperature calculation at the cold outlet
+  T_hot_in = hot_side_deheating.T_in;
+  T_hot_out = final_mix_hot.T_out;
+  W = W_deheat + W_cond + W_subc;
+
+  Tsat = hot_side_deheating.T_out;
+  h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(hot_side_deheating.P_in));
+  h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(hot_side_deheating.P_in));
+
+  /* Deheating */
+  // Energy balance
+  hot_side_deheating.W + cold_side_deheating.W = 0;
+  cold_side_deheating.W =W_deheat;
+
+  // Power Exchange
+  if hot_side_deheating.h_in > h_vap_sat then
+      hot_side_deheating.h_out = h_vap_sat; // if steam is superheated, it is first deheated
+  else
+      hot_side_deheating.h_out = hot_side_deheating.h_in;
+  end if;
+
+  /* Water level */
+  S = S_cond + S_subc;      // Deheating surface is neglected
+  S_subc =(level + water_level_rise)*S;
+
+  /* Condensing */
+  // Energy Balance
+  hot_side_condensing.W + cold_side_condensing.W = 0;
+  cold_side_condensing.W =W_cond;
+
+  // Power Exchange
+  hot_side_condensing.h_out = h_liq_sat;
+
+  HX_condensing.W =W_cond;
+  HX_condensing.Kth = Kth_cond * (1-fouling/100);
+  HX_condensing.S = S_cond;
+  HX_condensing.Q_cold = cold_side_deheating.Q;
+  HX_condensing.Q_hot = hot_side_deheating.Q;
+  HX_condensing.T_cold_in = cold_side_condensing.T_in;
+  HX_condensing.T_hot_in = hot_side_condensing.T_in;
+  HX_condensing.Cp_cold = WaterSteamMedium.specificHeatCapacityCp(cold_side_condensing.state_in);
+  HX_condensing.Cp_hot = 0; // Not used by NTU method in condenser mode
+
+  /* Subcooling */
+  // Energy Balance
+  hot_side_subcooling.W + cold_side_subcooling.W = 0;
+  cold_side_subcooling.W =W_subc;
+
+  // Power exchange
+  HX_subcooling.W =W_subc;
+  HX_subcooling.Kth = Kth_subc * (1-fouling/100);
+  HX_subcooling.S = S_subc;
+  HX_subcooling.Q_cold = cold_side_subcooling.Q;
+  HX_subcooling.Q_hot = hot_side_subcooling.Q;
+  HX_subcooling.T_cold_in = cold_side_subcooling.T_in;
+  HX_subcooling.T_hot_in = hot_side_subcooling.T_in;
+  HX_subcooling.Cp_cold = WaterSteamMedium.specificHeatCapacityCp(cold_side_subcooling.state_in);
+  HX_subcooling.Cp_hot = WaterSteamMedium.specificHeatCapacityCp(hot_side_subcooling.state_in);
+
+  // Indicators
+  FTR = T_cold_out - T_cold_in;
+  TTD = T_hot_in - T_cold_out;
+  DCA = T_hot_out - T_cold_in;
+  pinch = min(TTD, DCA);
+  assert(pinch > 0, "A negative pinch is reached", AssertionLevel.warning); // Ensure a positive pinch
+  assert(pinch > 1 or pinch < 0,  "A very low pinch (<1) is reached", AssertionLevel.warning); // Ensure a sufficient pinch
+
+  // Internal leaks
+  partition_plate.Q = 1e-5 + partition_plate_leak;
+  tube_rupture.Q = 1e-5 + tube_rupture_leak;
+  hot_side_partition_plate.Q = 1e-5 + hot_side_partition_plate_leak;
+
+  connect(cold_side_pipe.C_in, C_cold_in) annotation (Line(
+      points={{-140,0},{-162,0}},
+      color={28,108,200},
+      thickness=1));
+  connect(hot_side_deheating.C_out, hot_side_condensing.C_in) annotation (Line(
+      points={{77,20},{43,20}},
+      color={238,46,47},
+      thickness=1));
+
+  connect(cold_side_condensing.C_out, cold_side_deheating.C_in) annotation (
+      Line(
+      points={{48,-34},{80,-34}},
+      color={28,108,200},
+      thickness=1));
+
+  connect(partition_plate.C_in, cold_side_pipe.C_out) annotation (Line(points={{-110,-68},{-114,-68},{-114,0},{-120,0}}, color={217,67,180}));
+  connect(hot_side_condensing.C_out, hot_side_subcooling.C_in) annotation (Line(
+      points={{-3,20},{-45,20}},
+      color={238,46,47},
+      thickness=1));
+  connect(cold_side_condensing.C_in, cold_side_subcooling.C_out) annotation (
+      Line(
+      points={{0,-34},{-30,-34}},
+      color={28,108,200},
+      thickness=1));
+  connect(cold_side_deheating.C_out, final_mix_cold.C_in) annotation (Line(
+      points={{128,-34},{144,-34},{144,-28}},
+      color={28,108,200},
+      thickness=1));
+  connect(final_mix_cold.C_out, C_cold_out) annotation (Line(
+      points={{144,-8},{144,0},{160,0}},
+      color={28,108,200},
+      thickness=1));
+
+  connect(partition_plate.C_out, final_mix_cold.C_in) annotation (Line(points={{-90,-68},{144,-68},{144,-28}}, color={217,67,180}));
+
+  connect(cold_side_subcooling.C_in, cold_side_pipe.C_out) annotation (Line(
+      points={{-78,-34},{-114,-34},{-114,0},{-120,0}},
+      color={28,108,200},
+      thickness=1));
+  connect(final_mix_hot.C_out, C_hot_out) annotation (Line(points={{-40,-60},{0,
+          -60},{0,-80}},                                                                       color={238,46,47},
+      thickness=1));
+  connect(hot_side_subcooling.C_out, final_mix_hot.C_in) annotation (Line(
+      points={{-91,20},{-100,20},{-100,-60},{-60,-60}},
+      color={255,0,0},
+      thickness=1));
+  connect(cold_side_pipe.Kfr, Kfr_cold)
+    annotation (Line(points={{-130,4},{-130,38},{-192,38}},
+                                                  color={0,0,127}));
+  connect(hot_side_deheating.C_in, C_hot_in) annotation (Line(
+      points={{123,20},{140,20},{140,40},{0,40},{0,80}},
+      color={255,0,0},
+      thickness=1));
+  connect(tube_rupture.C_in, cold_side_subcooling.C_out) annotation (Line(
+      points={{-18,-20},{-18,-34},{-30,-34}},
+      color={28,108,200},
+      thickness=1));
+  connect(tube_rupture.C_out, hot_side_subcooling.C_in) annotation (Line(
+      points={{-18,0},{-18,20},{-45,20}},
+      color={238,46,47},
+      thickness=1));
+  connect(hot_side_subcooling.C_in,C_drains_in)  annotation (Line(points={{-45,20},
+          {-34,20},{-34,22},{95,22},{95,-80}},  color={28,108,200}));
+  connect(hot_side_partition_plate.C_out, final_mix_hot.C_in) annotation (Line(
+        points={{-6,-20},{-8,-20},{-8,-48},{-80,-48},{-80,-60},{-60,-60}},
+        color={28,108,200}));
+  connect(hot_side_partition_plate.C_in, C_hot_in) annotation (Line(points={{-6,
+          0},{-10,0},{-10,66},{0,66},{0,80}}, color={28,108,200}));
+    annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-160,-80},
+            {160,80}}),      graphics={
+        Polygon(
+          points={{-160,80},{-160,60},{-160,-62.5},{-160,-80},{-120,-80},{10,-80},
+              {160,-80},{160,80},{10,80},{-120,80},{-160,80}},
+          lineColor={28,108,200},
+          smooth=Smooth.Bezier,
+          lineThickness=1,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-98,60},{-98,38},{-98,-42},{-98,-62},{-78,-62},{14,-62},{142,
+              -62},{142,60},{10,60},{-78,60},{-98,60}},
+          smooth=Smooth.Bezier,
+          lineThickness=1,
+          fillColor={255,170,170},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None,
+          lineColor={0,0,0}),
+        Polygon(
+          points={{-126,-18},{-138,-18},{-138,-48},{-136,-60},{-80,-62},{12,-62},
+              {122,-62},{144,-18},{126,-18},{10,-20},{-112,-18},{-126,-18}},
+          smooth=Smooth.Bezier,
+          lineThickness=1,
+          fillColor={35,138,255},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None,
+          lineColor={0,0,0}),
+        Ellipse(
+          extent={{-88,-8},{-84,-14}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid,
+          startAngle=0,
+          endAngle=360),
+        Ellipse(
+          extent={{-74,-4},{-70,-10}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-54,-8},{-50,-14}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-30,-8},{-26,-14}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-10,-6},{-6,-12}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{10,0},{14,-6}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{36,-6},{40,-12}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{70,-10},{74,-16}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{114,14},{118,8}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-20,8},{-16,2}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{0,4},{4,-2}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{24,4},{28,-2}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{56,2},{60,-4}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{86,22},{90,16}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{80,6},{84,0}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{110,-2},{114,-8}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-94,20},{-90,14}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{16,22},{20,16}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-60,20},{-56,14}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-36,20},{-32,14}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-16,22},{-12,16}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-82,10},{-78,4}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-54,4},{-50,-2}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{50,18},{54,12}},
+          lineColor={28,108,200},
+          lineThickness=1,
+          fillColor={28,108,200},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-4,58.75},{4,58.75},{4,24.75},{8,24.75},{0,9.25},{-8,24.75},{-4,24.75},{-4,58.75}},
+          lineThickness=1,
+          fillColor={208,40,42},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None,
+          lineColor={0,0,0}),
+        Polygon(
+          points={{-108,42},{-116,44},{-116,-44},{-108,-44},{-98,-44},{16,-44},{
+              124,-44},{126,42},{12,42},{-100,42},{-108,42}},
+          lineColor={28,108,200},
+          smooth=Smooth.Bezier,
+          lineThickness=1),
+        Polygon(
+          points={{-114,48},{-120,48},{-120,-50},{-112,-50},{-100,-50},{10,-50},
+              {132,-50},{132,48},{10,48},{-100,48},{-114,48}},
+          lineColor={28,108,200},
+          smooth=Smooth.Bezier,
+          lineThickness=1),
+        Polygon(
+          points={{-114,30},{-120,30},{-120,-32},{-112,-32},{-100,-32},{14,-32},
+              {112,-32},{110,28},{12,30},{-100,30},{-114,30}},
+          lineColor={28,108,200},
+          smooth=Smooth.Bezier,
+          lineThickness=1),
+        Polygon(
+          points={{-118,36},{-124,36},{-124,-36},{-116,-38},{-106,-38},{6,-38},{
+              116,-40},{120,34},{8,36},{-104,36},{-118,36}},
+          lineColor={28,108,200},
+          smooth=Smooth.Bezier,
+          lineThickness=1),
+        Rectangle(
+          extent={{-150,50},{-100,-66}},
+          lineThickness=1,
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None),
+        Polygon(
+          points={{-148,60},{-148,36},{-148,20},{-148,20},{-122,20},{-102,20},{-102,20},{-102,60},{-102,60},{-120,60},{-148,60}},
+          smooth=Smooth.Bezier,
+          lineThickness=1,
+          fillColor={157,166,218},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None,
+          lineColor={0,0,0}),
+        Polygon(
+          points={{-148,-62},{-148,-38},{-148,-22},{-148,-22},{-122,-22},{-102,-22},{-102,-22},{-102,-62},{-102,-62},{-120,-62},{-148,-62}},
+          smooth=Smooth.Bezier,
+          lineThickness=1,
+          fillColor={157,166,218},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None,
+          lineColor={0,0,0})}),                                  Diagram(
+        coordinateSystem(preserveAspectRatio=false, extent={{-160,-80},{160,80}}), graphics={
+                                   Text(
+          extent={{-6,10},{54,-2}},
+          textColor={28,108,200},
+          textString="Condensing"),
+                  Text(
+          extent={{72,10},{132,-2}},
+          textColor={28,108,200},
+          textString="Deheating"), Text(
+          extent={{-84,10},{-24,-2}},
+          textColor={28,108,200},
+          textString="Subcooling")}));
+end Reheater_sideDrainsInlet;

--- a/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/HeatExchangers/Superheater.mo
@@ -5,13 +5,20 @@ model Superheater
   import MetroscopeModelingLibrary.Utilities.Units;
   import MetroscopeModelingLibrary.Utilities.Units.Inputs;
 
+  // New features: Kth_evap in addition to Kth_sup; option to input S_evap, S_sup, Q_vent with input_specifiations
+
+    // Specifications
+  parameter Boolean input_specs = false;
+  Inputs.InputArea S_evap;
+  Inputs.InputArea S_sup;
+  Units.PositiveMassFlowRate Q_vent;
+
   // Deheating
   Units.Power W_deheat;
 
   // Condensation
   Units.Power W_cond;
   parameter String HX_config="condenser";
-  parameter Inputs.InputArea S=100;
   Units.SpecificEnthalpy h_vap_sat_hot(start=h_vap_sat_0);
   Units.SpecificEnthalpy h_liq_sat_hot(start=h_liq_sat_0);
   Units.Temperature Tsat_hot;
@@ -22,7 +29,6 @@ model Superheater
   Units.Temperature Tsat_cold(start=T_cold_in_0);
 
   // Ventilation
-  parameter Units.PositiveMassFlowRate Q_vent = 1;
   Units.PositiveMassFlowRate Q_vent_faulty(start=Q_vent_0);
 
   // Definitions
@@ -50,6 +56,7 @@ model Superheater
 
   // Failure modes
   parameter Boolean faulty = false;
+  Units.Percentage fouling_or_drains_flooding(min = 0, max=100); // Fouling percentage, could also reflect reduced HT from condensate flooding in drain tank level rises
   Units.Percentage closed_vent(min = 0, max= 100); // Vent closing percentage
   Units.MassFlowRate tube_rupture_leak; // Tube rupture leak mass flow rate
 
@@ -117,8 +124,12 @@ model Superheater
         extent={{-17,-17},{17,17}},
         rotation=90,
         origin={39,1})));
-  Power.HeatExchange.NTUHeatExchange HX_condensing(config=HX_config, Q_hot_0=Q_hot_0, Q_cold_0=Q_cold_0,
-                                                   T_hot_in_0=T_hot_in_0, T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
+  Power.HeatExchange.NTUHeatExchange HX_condensing(
+    config=HX_config,
+    Q_hot_0=Q_hot_0,
+    Q_cold_0=Q_cold_0,
+    T_hot_in_0=T_hot_in_0,
+    T_cold_in_0=T_cold_in_0) annotation (Placement(transformation(
         extent={{-10,-21},{10,21}},
         rotation=270,
         origin={3,2})));
@@ -151,7 +162,14 @@ protected
   parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_hot_out_0));
 
 public
-  Utilities.Interfaces.GenericReal Kth annotation (Placement(transformation(
+  Utilities.Interfaces.GenericReal Kth_sup annotation (Placement(transformation(
+        extent={{-20,-20},{20,20}},
+        rotation=270,
+        origin={90,60}), iconTransformation(
+        extent={{-20,-20},{20,20}},
+        rotation=90,
+        origin={60,100})));
+  Utilities.Interfaces.GenericReal Kth_evap annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
         rotation=270,
         origin={90,60}), iconTransformation(
@@ -162,8 +180,15 @@ equation
 
   // Failure modes
   if not faulty then
+    fouling_or_drains_flooding = 0;
     closed_vent = 0;
     tube_rupture_leak = 0;
+  end if;
+
+  if not input_specs then
+    S_evap = 10;
+    S_sup = 100;
+    Q_vent = 1;
   end if;
 
   // Definitions
@@ -194,7 +219,7 @@ equation
   hot_side_deheating.W + cold_side_deheating.W = 0;
   cold_side_deheating.W = W_deheat;
 
-  // Power Exchange
+//Power Exchange
   if hot_side_deheating.h_in > h_vap_sat_hot then
       hot_side_deheating.h_out = h_vap_sat_hot; // if steam is superheated, it is first deheated
   else
@@ -209,8 +234,8 @@ equation
 
   // Power Exchange
   HX_condensing.W = W_cond;
-  HX_condensing.Kth = Kth;
-  HX_condensing.S = S;
+  HX_condensing.Kth = Kth_sup*(1-fouling_or_drains_flooding/100);
+  HX_condensing.S = S_sup;
   HX_condensing.Q_cold = cold_side_condensing.Q;
   HX_condensing.Q_hot = hot_side_condensing.Q;
   HX_condensing.T_cold_in = Tsat_cold;
@@ -218,10 +243,13 @@ equation
   HX_condensing.Cp_cold = WaterSteamMedium.specificHeatCapacityCp(cold_side_condensing.state_in);
   HX_condensing.Cp_hot = 0; // Not used by NTU method in condenser mode
 
-  /* Vaporising on cold side, condensation on hot side*/
+  /* Vaporising on cold side, condensation on hot side */
 
   hot_side_vaporising.W + cold_side_vaporising.W = 0;
   W_vap = cold_side_vaporising.W;
+
+  // Power exchange
+  W_vap = Kth_evap*(1-fouling_or_drains_flooding/100)*S_evap*(Tsat_hot - Tsat_cold);
 
   hot_side_vaporising.h_out = h_liq_sat_hot; // Hot steam is completely condensed
 
@@ -363,14 +391,16 @@ equation
         graphics={                 Text(
           extent={{-20,4},{20,-4}},
           textColor={238,46,47},
-          textString="Condensing",
           origin={-50,2},
-          rotation=90),            Text(
+          rotation=90,
+          textString="Condensing 1"),
+                                   Text(
           extent={{-20,4},{20,-4}},
           textColor={238,46,47},
-          textString="Condensing",
           origin={-50,-44},
-          rotation=90),            Text(
+          rotation=90,
+          textString="Condensing 2"),
+                                   Text(
           extent={{-20,4},{20,-4}},
           textColor={238,46,47},
           origin={-50,44},
@@ -380,7 +410,7 @@ equation
           textColor={28,108,200},
           origin={56,4},
           rotation=270,
-          textString="Superheating"),
+          textString="Superheating 1"),
                                    Text(
           extent={{-20,4},{20,-4}},
           textColor={28,108,200},
@@ -391,7 +421,7 @@ equation
           textColor={28,108,200},
           origin={56,48},
           rotation=270,
-          textString="Superheating"),
+          textString="Superheating 2"),
                                    Text(
           extent={{-20,4},{20,-4}},
           textColor={238,46,47},

--- a/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
@@ -8,65 +8,83 @@ model SteamDryer
   Units.SpecificEnthalpy h_vap_sat(start=h_vap_sat_0); // Saturated liquid enthalpy
   Units.SpecificEnthalpy h_liq_sat(start=h_liq_sat_0); // Saturated steam enthalpy
 
-  Units.Pressure P(start=P_0); // Pressure in dryer
-  Units.PositiveMassFlowRate Q_in(start=Q_in_0);
-                                              // Inlet mass flow rate
+  Units.Pressure P_in(start=P_in_0); // Pressure in dryer inlet
+  Units.PositiveMassFlowRate Q_in(start=Q_in_0); // Inlet mass flow rate
 
-  parameter Units.MassFraction x_steam_out=0.99; // Steam mass fraction at steam outlet
+  parameter Boolean faulty = false;
+  Real MS_outl_eff_decrease;
+
+  parameter Boolean input_specs = false;
+  Real x_steam_in;
+  Real x_steam_out;
+  Real MS_efficiency;
+
+  //Units.MassFraction
 
   // Initialization parameters
-  parameter Units.Pressure P_0 = 10e5;
+  parameter Units.Pressure P_in_0 = 10e5;
+  parameter Units.Pressure P_out_0 = 9e5;
   parameter Units.Temperature T_0 = 273.15 + 180;
   parameter Units.SpecificEnthalpy h_in_0 = 2e6;
   parameter Units.PositiveMassFlowRate Q_in_0=500;
   parameter Units.PositiveMassFlowRate Q_liq_0 = 0.5*Q_in_0;
   parameter Units.PositiveMassFlowRate Q_vap_0 = Q_in_0 - Q_liq_0;
 
-  Connectors.Inlet C_in(P(start=P_0), Q(start=Q_in_0)) annotation (Placement(transformation(extent={{-110,30},{-90,50}}), iconTransformation(extent={{-110,30},{-90,50}})));
-  Connectors.Outlet C_hot_steam(P(start=P_0), Q(start=-Q_vap_0),
+  Connectors.Inlet C_in(P(start=P_in_0), Q(start=Q_in_0)) annotation (Placement(transformation(extent={{-110,30},{-90,50}}), iconTransformation(extent={{-110,30},{-90,50}})));
+  Connectors.Outlet C_hot_steam(P(start=P_in_0), Q(start=-Q_vap_0),
     h_outflow(start=h_vap_sat_0))                                 annotation (Placement(transformation(extent={{90,30},{110,50}})));
-  Connectors.Outlet C_hot_liquid(P(start=P_0), Q(start=-Q_liq_0),
+  Connectors.Outlet C_hot_liquid(P(start=P_in_0), Q(start=-Q_liq_0),
     h_outflow(start=h_liq_sat_0))                                  annotation (Placement(transformation(extent={{90,-50},{110,-30}})));
   BaseClasses.IsoPFlowModel steam_phase(
     T_in_0=T_0,
     T_out_0=T_0,
     h_in_0=h_in_0,
-    h_out_0=h_vap_sat_0,                P_0=P_0,
-    Q_0=Q_vap_0)                                               annotation (Placement(transformation(extent={{26,30},{46,50}})));
+    h_out_0=h_vap_sat_0,                P_0=P_in_0,
+    Q_0=Q_vap_0)                                               annotation (Placement(transformation(extent={{6,30},{
+            26,50}})));
   BaseClasses.IsoPFlowModel liquid_phase(
     T_in_0=T_0,
     T_out_0=T_0,
     h_in_0=h_in_0,
-    h_out_0=h_liq_sat_0,                 P_0=P_0,
+    h_out_0=h_liq_sat_0,                 P_0=P_in_0,
     Q_0=Q_liq_0)                                                annotation (Placement(transformation(extent={{26,-50},{46,-30}})));
 protected
-  parameter Units.SpecificEnthalpy h_vap_sat_0 = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_0));
-  parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_0));
+  parameter Units.SpecificEnthalpy h_vap_sat_0 = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_in_0));
+  parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_in_0));
 equation
 
+  if not faulty then
+    MS_outl_eff_decrease = 0;
+  end if;
+
+  if not input_specs then
+    MS_efficiency = 0.99;
+  end if;
+
   // Definitions
-  P = C_in.P;
+  P_in = C_in.P;
   Q_in = steam_phase.Q + liquid_phase.Q;
 
-  // Saturation at both outlets
-  h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P));
-  h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P));
+  // Saturation at inlet and both outlets
+  h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_in));
+  h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_in));
+
+  C_in.h_outflow = x_steam_in*h_vap_sat + (1 - x_steam_in)*h_liq_sat;
   steam_phase.h_out = x_steam_out * h_vap_sat + (1-x_steam_out)*h_liq_sat;
   liquid_phase.h_out = h_liq_sat;
+  x_steam_out = (MS_efficiency - MS_outl_eff_decrease)*(1-x_steam_in)+x_steam_in;
 
   // Energy balance
   steam_phase.W + liquid_phase.W = 0;
 
-  connect(liquid_phase.C_in, C_in) annotation (Line(points={{26,-40},{-40,-40},{
-          -40,40},{-100,40}},
-                            color={28,108,200}));
-  connect(steam_phase.C_in, C_in) annotation (Line(points={{26,40},{-40,40},{-40,
-          40},{-100,40}},
-                        color={28,108,200}));
-  connect(steam_phase.C_out,C_hot_steam)
-    annotation (Line(points={{46,40},{100,40}}, color={28,108,200}));
-  connect(liquid_phase.C_out,C_hot_liquid)
+  connect(steam_phase.C_in, C_in)
+    annotation (Line(points={{6,40},{-100,40}}, color={28,108,200}));
+  connect(liquid_phase.C_in, C_in) annotation (Line(points={{26,-40},{-16,-40},{
+          -16,-38},{-52,-38},{-52,40},{-100,40}}, color={28,108,200}));
+  connect(liquid_phase.C_out, C_hot_liquid)
     annotation (Line(points={{46,-40},{100,-40}}, color={28,108,200}));
+  connect(steam_phase.C_out, C_hot_steam)
+    annotation (Line(points={{26,40},{100,40}}, color={28,108,200}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,120}}), graphics={
         Rectangle(


### PR DESCRIPTION
## Goal

Describe the big picture of your changes here (one sentence). 

Modified heat exchanger and steam dryer components to add options for inputting specifications, added new faults to some components, modified NTU Heat Exchange element with an epsilon warning, and other small changes listed below


## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [x ] New feature
- [ ] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [x ] Breaking change (If yes, make sure to point it out in the changelog)
         - Changed configuration of Reheater subcooling portion
- [ ] Non-Breaking change

## Checklist

- [ ] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [x ] I have performed a self-review of my own code
       - I verified that all tests simulate too
- [x ] I have checked that all existing tests pass
- [x ] I have checked that my work is compatible with [OpenModelica](https://openmodelica.org/)
- [x ] I have added/updated tests that prove my development works and does not break anything.
- [ ] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
       - Will do this with new faults proposed if they are approved
- [ ] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
     - Will do this if PR is approved
- [ x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.

General changes
- the option "input specs" is created for all heat exchangers which allows for inputting specification if set to true. For most heaters it only allows the input of area S, and more specifications could be added in the future as desired (ex. heater height and level)
- Hot-side partition plate leakadded to dry reheater and reheater,  is modeled as incoming hot-side steam bypassing the heat exchange portion and joining with the hot-side outlet. This is documented as having happened at Turkey Point NPP (https://asmedigitalcollection.asme.org/POWER/proceedings-abstract/POWER2018/51401/V002T07A003/277493)


Superheater
- Added "input_specs" which allows you to specify S_evap, S_sup and Q_vent
- Changed Kth to Kth_sup to represent the superheating heat exchange coefficient, and added a Kth_vap to represent vaporizing heat exchange coefficient (not to to be calibrated, just for the interest of studying if desired)
- Added fouling fault, and changed name from "fouling" to "fouling_or_condensate_flooding" since a documented issue in some reheaters is the reheating steam condensing too quickly and flooding the reheater, which reduces the effective heat transfer coefficient. (Page 376-380, and bullet #2 on p. 380 in particular, in https://www.jstage.jst.go.jp/article/jpes/3/2/3_2_368/_pdf/-char/en)

LiqLiqHX
- "input_specs" option for setting area S
- Tube rupture leak added
- Changed QCp_max_side to "unknown"

DryReheater
- Made the option "input_specs" that allows you to input area S if set to true.
- Added a hot-side partition plate leak that is modeled as incoming hot-side steam bypassing the heat exchange portion and joining with the hot-side outlet.

Reheater
- "input_specs" to specify total area S
- Added hot-side partition plate leak
- Changed subcooling configuration to countercurrent which is arguably more accurate
- Changed QCp_max_side to "unknown"

Reheater_sideDrainsInlet
- Identical to reheater, but the drains from the upstream heater joins the condensed extraction steam, right before the subcooling section.
- From studies done with this version of the reheater on real data, the subcooling heat duty and Kth_subc tend to be higher than the standard reheater, while the condensing duty and Kth_cond tend to be lower correspondingly. This is because the upstream drains may flash slightly upon encountering the pressure of the heater, and so this small amount of vapor produced is now condensed by the subcooling section after mixing with the condensed extraction steam. Also, Kth_subc is more prone to seasonality in this version, because it is more influenced by variations in upstream drains flow rate and temperature which may be seasonal. When comparing both this and the original heater versions in the Quad Cities model, the direct model results and fault detections are practically identical in both cases when the same quantile is used and seasonality is accounted for properly. A thorough investigation has not been done to compare the fault matrices produced from both models. Theoretically, faults that occur external to the heater (e.g. valves leaks) should have the same signatures for both versions because the overall energy balance of both heater types are identical. The magnitudes of the impact of internal leaks on the reheater condensate and drain temperatures may be slightly different between the two versions, but the signs of the fault impacts likely would not change.

Condenser
- "input_specs" to specify water height based on the input hotwell level, which impacts the hydrostatic pressure increase, and to specif surface area S

SteamDryer
- Mde dryer efficiency a component input and defined x_steam_out in terms of drying efficiency
- Added a fault where dryer efficiency is decreased
- Made an "input_specs" option for specifying the dryer efficiency
- Change P_0 to P_in_0 and added P_out_0 too (no practical change but did it a while a go for some reason and am too lazy to change back - but could if worthwhile)

NTUHeatExchange
- Added warning for each heat exchange configuration for when epsilon is above 98% of its maximum allowed value