### PR TITLE
update to steam dryer model using efficiency as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
     - 🔧 Fix variables declaration for incondensable in ACC [#558](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/558)
 
 ### 💥 Changed <!--Make sure to add a link to the PR and issues related to your change-->
-- Made efficiency the default input of the steam dryer rather than outlet vapor fraction, and option to specify efficieny, and fault that reduces efficiency (#594 https://github.com/Metroscope-dev/metroscope-modeling-library/issues/594)
+- Made efficiency the default input of the steam dryer rather than outlet vapor fraction, and option to specify efficieny, and fault that reduces efficiency (#594 https://github.com/Metroscope-dev/metroscope-modeling-library/issues/594). To incorporate into existing models without changing any results, set input_specs = true and define the outlet vapor fraction as 0.99, which was the previous default
 
 ### 🔥 Removed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Use [gitmoji](https://gitmoji.dev/) to identify your changes.
     - 🔧 Fix variables declaration for incondensable in ACC [#558](https://github.com/Metroscope-dev/metroscope-modeling-library/pull/558)
 
 ### 💥 Changed <!--Make sure to add a link to the PR and issues related to your change-->
+- Made efficiency the default input of the steam dryer rather than outlet vapor fraction, and option to specify efficieny, and fault that reduces efficiency (#594 https://github.com/Metroscope-dev/metroscope-modeling-library/issues/594)
 
 ### 🔥 Removed 
 

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/Volumes/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/Volumes/SteamDryer.mo
@@ -2,32 +2,43 @@ within MetroscopeModelingLibrary.Tests.WaterSteam.Volumes;
 model SteamDryer
   extends MetroscopeModelingLibrary.Utilities.Icons.Tests.WaterSteamTestIcon;
 
+  // To input either efficiency or x_steam_out, put:
+  // --> steamDryer (input_specs = true);
+
   // Boundary Conditions
   input Utilities.Units.Pressure P_source(start=10e5) "Pa";
   input Utilities.Units.NegativeMassFlowRate Q_source(start=-500) "kg/s";
   input Utilities.Units.SpecificEnthalpy h_source(start=2e6) "J/kg";
 
   // Component parameters
-  parameter Real x_steam_out = 0.9;
+  output Real x_steam_in;
+  output Real x_steam_out;
 
-  .MetroscopeModelingLibrary.WaterSteam.Volumes.SteamDryer steamDryer annotation (Placement(transformation(extent={{-32,-26},{28,34}})));
+  .MetroscopeModelingLibrary.WaterSteam.Volumes.SteamDryer steamDryer(
+      input_specs=true)
+    annotation (Placement(transformation(extent={{-32,-26},{28,34}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Source source annotation (Placement(transformation(extent={{-80,2},{-60,22}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink steam_sink annotation (Placement(transformation(extent={{56,2},{76,22}})));
   .MetroscopeModelingLibrary.WaterSteam.BoundaryConditions.Sink liquid_sink annotation (Placement(transformation(extent={{56,-50},{76,-30}})));
+
 equation
 
   // Boundary conditions
   source.P_out = P_source;
   source.Q_out = Q_source;
   source.h_out = h_source;
+  steamDryer.x_steam_in = x_steam_in; // A consequence of the boundary conditions
 
-  // Component parameters
+  // Specifications, for if "input_specs" is set to true
+  steamDryer.MS_efficiency = 0.99;
+
+  // Output observables
   steamDryer.x_steam_out = x_steam_out;
 
-  connect(steamDryer.C_in, source.C_out) annotation (Line(points={{-32,12.1818},{-32,12},{-65,12}},
-                                            color={28,108,200}));
-  connect(steamDryer.C_hot_steam, steam_sink.C_in) annotation (Line(points={{28,12.1818},{28,12},{61,12}},
-                                                  color={28,108,200}));
+  connect(steamDryer.C_in, source.C_out) annotation (Line(points={{-32,12.1818},
+          {-32,12},{-65,12}},               color={28,108,200}));
+  connect(steamDryer.C_hot_steam, steam_sink.C_in) annotation (Line(points={{28,
+          12.1818},{28,12},{61,12}},              color={28,108,200}));
   connect(steamDryer.C_hot_liquid, liquid_sink.C_in) annotation (Line(points={{28,-9.63636},{28,-8},{52,-8},{52,-40},{61,-40}},
                                                       color={28,108,200}));
 end SteamDryer;

--- a/MetroscopeModelingLibrary/Tests/WaterSteam/Volumes/SteamDryer_faulty.mo
+++ b/MetroscopeModelingLibrary/Tests/WaterSteam/Volumes/SteamDryer_faulty.mo
@@ -1,0 +1,9 @@
+within MetroscopeModelingLibrary.Tests.WaterSteam.Volumes;
+model SteamDryer_faulty
+  extends SteamDryer     (steamDryer( faulty = true));
+  input Real Fault_SteamDryer_Eff_Decrease( start = 0);
+
+equation
+  steamDryer.MS_eff_decrease = Fault_SteamDryer_Eff_Decrease + 0.1*time;
+
+end SteamDryer_faulty;

--- a/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
@@ -58,7 +58,7 @@ equation
   end if;
 
   if not input_specs then
-    MS_efficiency = 0.99;
+    MS_efficiency = 0.99; // You can still set the outlet steam fraction if you'd like, just set input_specs = true and define it in the moedl
   end if;
 
   // Definitions

--- a/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
@@ -8,65 +8,83 @@ model SteamDryer
   Units.SpecificEnthalpy h_vap_sat(start=h_vap_sat_0); // Saturated liquid enthalpy
   Units.SpecificEnthalpy h_liq_sat(start=h_liq_sat_0); // Saturated steam enthalpy
 
-  Units.Pressure P(start=P_0); // Pressure in dryer
-  Units.PositiveMassFlowRate Q_in(start=Q_in_0);
-                                              // Inlet mass flow rate
+  Units.Pressure P_in(start=P_in_0); // Pressure in dryer inlet
+  Units.PositiveMassFlowRate Q_in(start=Q_in_0); // Inlet mass flow rate
 
-  parameter Units.MassFraction x_steam_out=0.99; // Steam mass fraction at steam outlet
+  parameter Boolean faulty = false;
+  Real MS_eff_decrease;
+
+  parameter Boolean input_specs = false;
+  Real x_steam_in;
+  Real x_steam_out;
+  Real MS_efficiency;
+
+  //Units.MassFraction
 
   // Initialization parameters
-  parameter Units.Pressure P_0 = 10e5;
+  parameter Units.Pressure P_in_0 = 10e5;
+  parameter Units.Pressure P_out_0 = 9e5;
   parameter Units.Temperature T_0 = 273.15 + 180;
   parameter Units.SpecificEnthalpy h_in_0 = 2e6;
   parameter Units.PositiveMassFlowRate Q_in_0=500;
   parameter Units.PositiveMassFlowRate Q_liq_0 = 0.5*Q_in_0;
   parameter Units.PositiveMassFlowRate Q_vap_0 = Q_in_0 - Q_liq_0;
 
-  Connectors.Inlet C_in(P(start=P_0), Q(start=Q_in_0)) annotation (Placement(transformation(extent={{-110,30},{-90,50}}), iconTransformation(extent={{-110,30},{-90,50}})));
-  Connectors.Outlet C_hot_steam(P(start=P_0), Q(start=-Q_vap_0),
+  Connectors.Inlet C_in(P(start=P_in_0), Q(start=Q_in_0)) annotation (Placement(transformation(extent={{-110,30},{-90,50}}), iconTransformation(extent={{-110,30},{-90,50}})));
+  Connectors.Outlet C_hot_steam(P(start=P_in_0), Q(start=-Q_vap_0),
     h_outflow(start=h_vap_sat_0))                                 annotation (Placement(transformation(extent={{90,30},{110,50}})));
-  Connectors.Outlet C_hot_liquid(P(start=P_0), Q(start=-Q_liq_0),
+  Connectors.Outlet C_hot_liquid(P(start=P_in_0), Q(start=-Q_liq_0),
     h_outflow(start=h_liq_sat_0))                                  annotation (Placement(transformation(extent={{90,-50},{110,-30}})));
   BaseClasses.IsoPFlowModel steam_phase(
     T_in_0=T_0,
     T_out_0=T_0,
     h_in_0=h_in_0,
-    h_out_0=h_vap_sat_0,                P_0=P_0,
-    Q_0=Q_vap_0)                                               annotation (Placement(transformation(extent={{26,30},{46,50}})));
+    h_out_0=h_vap_sat_0,                P_0=P_in_0,
+    Q_0=Q_vap_0)                                               annotation (Placement(transformation(extent={{6,30},{
+            26,50}})));
   BaseClasses.IsoPFlowModel liquid_phase(
     T_in_0=T_0,
     T_out_0=T_0,
     h_in_0=h_in_0,
-    h_out_0=h_liq_sat_0,                 P_0=P_0,
+    h_out_0=h_liq_sat_0,                 P_0=P_in_0,
     Q_0=Q_liq_0)                                                annotation (Placement(transformation(extent={{26,-50},{46,-30}})));
 protected
-  parameter Units.SpecificEnthalpy h_vap_sat_0 = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_0));
-  parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_0));
+  parameter Units.SpecificEnthalpy h_vap_sat_0 = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_in_0));
+  parameter Units.SpecificEnthalpy h_liq_sat_0 = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_in_0));
 equation
 
+  if not faulty then
+    MS_eff_decrease = 0;
+  end if;
+
+  if not input_specs then
+    MS_efficiency = 0.99;
+  end if;
+
   // Definitions
-  P = C_in.P;
+  P_in = C_in.P;
   Q_in = steam_phase.Q + liquid_phase.Q;
 
-  // Saturation at both outlets
-  h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P));
-  h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P));
+  // Saturation at inlet and both outlets
+  h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_in));
+  h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_in));
+
+  C_in.h_outflow = x_steam_in*h_vap_sat + (1 - x_steam_in)*h_liq_sat;
   steam_phase.h_out = x_steam_out * h_vap_sat + (1-x_steam_out)*h_liq_sat;
   liquid_phase.h_out = h_liq_sat;
+  x_steam_out = x_steam_in/(1-(MS_efficiency - MS_eff_decrease)*(1-x_steam_in));
 
   // Energy balance
   steam_phase.W + liquid_phase.W = 0;
 
-  connect(liquid_phase.C_in, C_in) annotation (Line(points={{26,-40},{-40,-40},{
-          -40,40},{-100,40}},
-                            color={28,108,200}));
-  connect(steam_phase.C_in, C_in) annotation (Line(points={{26,40},{-40,40},{-40,
-          40},{-100,40}},
-                        color={28,108,200}));
-  connect(steam_phase.C_out,C_hot_steam)
-    annotation (Line(points={{46,40},{100,40}}, color={28,108,200}));
-  connect(liquid_phase.C_out,C_hot_liquid)
+  connect(steam_phase.C_in, C_in)
+    annotation (Line(points={{6,40},{-100,40}}, color={28,108,200}));
+  connect(liquid_phase.C_in, C_in) annotation (Line(points={{26,-40},{-16,-40},{
+          -16,-38},{-52,-38},{-52,40},{-100,40}}, color={28,108,200}));
+  connect(liquid_phase.C_out, C_hot_liquid)
     annotation (Line(points={{46,-40},{100,-40}}, color={28,108,200}));
+  connect(steam_phase.C_out, C_hot_steam)
+    annotation (Line(points={{26,40},{100,40}}, color={28,108,200}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,120}}), graphics={
         Rectangle(

--- a/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
+++ b/MetroscopeModelingLibrary/WaterSteam/Volumes/SteamDryer.mo
@@ -69,7 +69,7 @@ equation
   h_vap_sat = WaterSteamMedium.dewEnthalpy(WaterSteamMedium.setSat_p(P_in));
   h_liq_sat = WaterSteamMedium.bubbleEnthalpy(WaterSteamMedium.setSat_p(P_in));
 
-  C_in.h_outflow = x_steam_in*h_vap_sat + (1 - x_steam_in)*h_liq_sat;
+  steam_phase.h_in = x_steam_in*h_vap_sat + (1 - x_steam_in)*h_liq_sat;
   steam_phase.h_out = x_steam_out * h_vap_sat + (1-x_steam_out)*h_liq_sat;
   liquid_phase.h_out = h_liq_sat;
   x_steam_out = x_steam_in/(1-(MS_efficiency - MS_eff_decrease)*(1-x_steam_in));


### PR DESCRIPTION

## Goal

Describe the big picture of your changes here (one sentence). 

Update steam dryer component so that efficeincy is input instead of outlet vapor fraction, with the option to input steam fraction manually and option to model a steam fraction efficiency decrease fault. New steam dryer healty and fault test included. Response to the following issue:
https://github.com/Metroscope-dev/metroscope-modeling-library/issues/594

If you wish to incorporate into existing models and not change results at all, then set input_specs = true and define the outlet steam fraction as 0.99

## Type of change <!--- replace `[ ]` by `[x]` to render checkboxes properly -->

- [ ] Bugfix
- [ ] New feature
- [ x] Refactoring change
- [ ] Release & Version Update (don't forget to change the version number in `package.mo`)

Will it break anything in previous models ?

- [ ] Breaking change (If yes, make sure to point it out in the changelog)
- [ x] Non-Breaking change

## Checklist

- [x ] I have added the appropriate tags, reviewers, projects (and detailed the size and priority of my PR) and linked issues to this PR
- [ x] I have performed a self-review of my own code
- [ x] I have checked that all existing tests pass
- [ x] I have checked that my work is compatible with [OpenModelica](https://openmodelica.org/)
- [ x] I have added/updated tests that prove my development works and does not break anything.
- [ x] I have made corresponding changes or additions to the documentation (in [Notion documentation](https://www.notion.so/metroscope/Metroscope-Modeling-Library-Documentation-MML3-WIP-50c8703c294446059d3b4a70d6ae4a71))
- [ x] I have added corresponding entries to the [Changelog](../CHANGELOG.md)
- [ x] I have checked for conflicts with target branch, and merged/rebased in consequence

You can also fill these out after creating the PR, but make sure to **check them all before submitting your PR for review**.
